### PR TITLE
do not use rdkafka-ruby locking that is extreme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Expose `#name` on the consumer and producer (mensfeld)
 * Introduce producer partitions count metadata cache (mensfeld)
 * Retry metadta fetches on certain errors with a backoff (mensfeld)
+* Do not lock access to underlying native kafka client and rely on Karafka granular locking (mensfeld)
 
 # 0.12.3
 - Include backtrace in non-raised binded errors.

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -37,9 +37,7 @@ module Rdkafka
     def with_inner
       return if @inner.nil?
 
-      @access_mutex.synchronize do
-        yield @inner
-      end
+      yield @inner
     end
 
     def finalizer

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.13.0"
+  VERSION = "0.13.0.beta2"
   LIBRDKAFKA_VERSION = "2.0.2"
   LIBRDKAFKA_SOURCE_SHA256 = "f321bcb1e015a34114c83cf1aa7b99ee260236aab096b85c003170c90a47ca9d"
 end


### PR DESCRIPTION
This locking is bad and while it may protect less experienced users, it imposes drastic API limitations. We do not need it as Karafka provides granular locking.

ref https://github.com/appsignal/rdkafka-ruby/issues/260