### PR TITLE
Remove unused variable low from Consumer#lag

### DIFF
--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -327,7 +327,7 @@ module Rdkafka
         topic_out = {}
         partitions.each do |p|
           next if p.offset.nil?
-          low, high = query_watermark_offsets(
+          _, high = query_watermark_offsets(
             topic,
             p.partition,
             watermark_timeout_ms


### PR DESCRIPTION
Fix unused `low` variable warning