### PR TITLE
Always poll for oauth bearer to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.4
+* Always call initial poll on librdkafka to make sure oauth bearer cb is handled pre-operations.
+
 # 0.13.3
 * Bump librdkafka to 2.2.0
 

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -27,6 +27,9 @@ module Rdkafka
       # counter for operations in progress using inner
       @operations_in_progress = 0
 
+      # Trigger initial poll to make sure oauthbearer cb and other initial cb are handled
+      Rdkafka::Bindings.rd_kafka_poll(inner, 0)
+
       if run_polling_thread
         # Start thread to poll client for delivery callbacks,
         # not used in consumer.

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.13.3"
+  VERSION = "0.13.4"
   LIBRDKAFKA_VERSION = "2.2.0"
   LIBRDKAFKA_SOURCE_SHA256 = "af9a820cbecbc64115629471df7c7cecd40403b6c34bfdbb9223152677a47226"
 end


### PR DESCRIPTION
Always call non-blocking poll to handle oauth bearer callback initialization and other callbacks 