### PR TITLE
Ensure error is built into final report when bypassing wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.5
+* Fix DeliveryReport `create_result#error` being nil despite an error being associated with it
+
 # 0.13.4
 * Always call initial poll on librdkafka to make sure oauth bearer cb is handled pre-operations.
 

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -18,7 +18,12 @@ module Rdkafka
 
       # @return [DeliveryReport] a report on the delivery of the message
       def create_result
-        DeliveryReport.new(self[:partition], self[:offset], self[:topic_name].read_string)
+        DeliveryReport.new(
+          self[:partition],
+          self[:offset],
+          self[:topic_name].read_string,
+          self[:response] == 0 ? nil : RdkafkaError.new(self[:response])
+        )
       end
     end
   end

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -34,7 +34,6 @@ module Rdkafka
             RdkafkaError.new(self[:response])
           )
         end
-
       end
     end
   end

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -18,12 +18,23 @@ module Rdkafka
 
       # @return [DeliveryReport] a report on the delivery of the message
       def create_result
-        DeliveryReport.new(
-          self[:partition],
-          self[:offset],
-          self[:topic_name].read_string,
-          self[:response] == 0 ? nil : RdkafkaError.new(self[:response])
-        )
+        if self[:response] == 0
+          DeliveryReport.new(
+            self[:partition],
+            self[:offset],
+            self[:topic_name].read_string
+          )
+        else
+          DeliveryReport.new(
+            self[:partition],
+            self[:offset],
+            # For part of errors, we will not get a topic name reference and in cases like this
+            # we should not return it
+            self[:topic_name].null? ? nil : self[:topic_name].read_string,
+            RdkafkaError.new(self[:response])
+          )
+        end
+
       end
     end
   end

--- a/lib/rdkafka/producer/delivery_report.rb
+++ b/lib/rdkafka/producer/delivery_report.rb
@@ -12,8 +12,9 @@ module Rdkafka
       # @return [Integer]
       attr_reader :offset
 
-      # The name of the topic this message was produced to.
-      # @return [String]
+      # The name of the topic this message was produced to or nil in case delivery failed and we
+      #   we not able to get the topic reference
+      # @return [String, nil]
       attr_reader :topic_name
 
       # Error in case happen during produce.

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.13.4"
+  VERSION = "0.13.5"
   LIBRDKAFKA_VERSION = "2.2.0"
   LIBRDKAFKA_SOURCE_SHA256 = "af9a820cbecbc64115629471df7c7cecd40403b6c34bfdbb9223152677a47226"
 end

--- a/spec/rdkafka/producer/delivery_handle_spec.rb
+++ b/spec/rdkafka/producer/delivery_handle_spec.rb
@@ -44,4 +44,19 @@ describe Rdkafka::Producer::DeliveryHandle do
       end
     end
   end
+
+  describe '#create_result' do
+    let(:pending_handle) { false }
+    let(:report) { subject.create_result }
+
+    context 'when response is 0' do
+      it { expect(report.error).to eq(nil) }
+    end
+
+    context 'when response is not 0' do
+      let(:response) { 1 }
+
+      it { expect(report.error).to eq(Rdkafka::RdkafkaError.new(response)) }
+    end
+  end
 end

--- a/spec/rdkafka/producer_spec.rb
+++ b/spec/rdkafka/producer_spec.rb
@@ -627,4 +627,20 @@ describe Rdkafka::Producer do
       end
     end
   end
+
+  context "when not being able to deliver the message" do
+    let(:producer) do
+      rdkafka_producer_config(
+        "bootstrap.servers": "localhost:9093",
+        "message.timeout.ms": 100
+      ).producer
+    end
+
+    it "should contain the error in the response when not deliverable" do
+      handler = producer.produce(topic: 'produce_test_topic', payload: nil)
+      # Wait for the async callbacks and delivery registry to update
+      sleep(2)
+      expect(handler.create_result.error).to be_a(Rdkafka::RdkafkaError)
+    end
+  end
 end


### PR DESCRIPTION
This PR ensures, that for async flows with granular message tracking, we can materialize the result with an error if an error occurs without having to resolve the error. This should allow for much better control of dispatches if needed. 