### PR TITLE
Return better errors on consumer poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **[Feature]** Add `Admin#create_partitions` (mensfeld)
 - **[Feature]** Add `Admin#delete_group` utility (piotaixr)
 - **[Feature]** Add Create and Delete ACL Feature To Admin Functions (vgnanasekaran)
+- **[Enhancement]** Improve error reporting on `unknown_topic_or_part` and include missing topic (mensfeld)
+- **[Enhancement]** Improve error reporting on consumer polling errors (mensfeld)
 
 ## 0.14.0 (2023-11-17)
 - [Enhancement] Bump librdkafka to 2.3.0

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -522,18 +522,17 @@ module Rdkafka
       message_ptr = @native_kafka.with_inner do |inner|
         Rdkafka::Bindings.rd_kafka_consumer_poll(inner, timeout_ms)
       end
-      if message_ptr.null?
-        nil
-      else
-        # Create struct wrapper
-        native_message = Rdkafka::Bindings::Message.new(message_ptr)
-        # Raise error if needed
 
-        Rdkafka::RdkafkaError.validate!(native_message[:err])
+      return nil if message_ptr.null?
 
-        # Create a message to pass out
-        Rdkafka::Consumer::Message.new(native_message)
-      end
+      # Create struct wrapper
+      native_message = Rdkafka::Bindings::Message.new(message_ptr)
+
+      # Create a message to pass out
+      return Rdkafka::Consumer::Message.new(native_message) if native_message[:err].zero?
+
+      # Raise error if needed
+      Rdkafka::RdkafkaError.validate!(native_message)
     ensure
       # Clean up rdkafka message if there is one
       if message_ptr && !message_ptr.null?

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -48,6 +48,8 @@ module Rdkafka
 
           new(response_ptr_or_code, message_prefix, broker_message: broker_message)
         when Bindings::Message
+          return false if response_ptr_or_code[:err].zero?
+
           unless response_ptr_or_code[:payload].null?
             message_prefix ||= response_ptr_or_code[:payload].read_string(response_ptr_or_code[:len])
           end

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -42,8 +42,17 @@ module Rdkafka
       end
 
       def build(response_ptr_or_code, message_prefix = nil, broker_message: nil)
-        if response_ptr_or_code.is_a?(Integer)
-          response_ptr_or_code.zero? ? false : new(response_ptr_or_code, message_prefix, broker_message: broker_message)
+        case response_ptr_or_code
+        when Integer
+          return false if response_ptr_or_code.zero?
+
+          new(response_ptr_or_code, message_prefix, broker_message: broker_message)
+        when Bindings::Message
+          unless response_ptr_or_code[:payload].null?
+            message_prefix ||= response_ptr_or_code[:payload].read_string(response_ptr_or_code[:len])
+          end
+
+          new(response_ptr_or_code[:err], message_prefix, broker_message: broker_message)
         else
           build_from_c(response_ptr_or_code, message_prefix)
         end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -702,6 +702,15 @@ describe Rdkafka::Consumer do
         consumer.poll(100)
       }.to raise_error Rdkafka::RdkafkaError
     end
+
+    it "expect to raise error when polling non-existing topic" do
+      missing_topic = SecureRandom.uuid
+      consumer.subscribe(missing_topic)
+
+      expect {
+        consumer.poll(1_000)
+      }.to raise_error Rdkafka::RdkafkaError, /Subscribed topic not available: #{missing_topic}/
+    end
   end
 
   describe "#poll with headers" do


### PR DESCRIPTION
this will be backported to rdkafka-ruby as well

Note: This is a trade-off. We should introduce a correct full error handling from pointers instead of using the message object, however this will require a bigger refactor that I plan to do once we have all things backported and aligned.

ref https://github.com/karafka/rdkafka-ruby/issues/357
