### PR TITLE
v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Rdkafka Changelog
 
-## 0.15.0 (Unreleased)
+## 0.14.1 (2023-12-02)
 - **[Feature]** Add `Admin#metadata` (mensfeld)
 - **[Feature]** Add `Admin#create_partitions` (mensfeld)
 - **[Feature]** Add `Admin#delete_group` utility (piotaixr)

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.15.0"
+  VERSION = "0.14.1"
   LIBRDKAFKA_VERSION = "2.3.0"
   LIBRDKAFKA_SOURCE_SHA256 = "2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12"
 end


### PR DESCRIPTION
Release. I changed from 0.15.0 as there is no rdkafka bump and we can use 0.15 or 0.16 to merge rdkafka and karafka-rdkafka later.
