### PR TITLE
Fix `uint8_t` does not exist on Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.14.2 (Unreleased)
 - [Enhancement] Alias `topic_name` as `topic` in the delivery report (mensfeld)
 - [Fix] Fix return type on `#rd_kafka_poll` (mensfeld)
+- [Fix] `uint8_t` does not exist on Apple Silicon (mensfeld)
 
 ## 0.14.1 (2023-12-02)
 - **[Feature]** Add `Admin#metadata` (mensfeld)

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -454,9 +454,9 @@ module Rdkafka
     class NativeError < FFI::Struct # rd_kafka_error_t
       layout :code, :int32,
              :errstr, :pointer,
-             :fatal, :uint8_t,
-             :retriable, :uint8_t,
-             :txn_requires_abort, :uint8_t
+             :fatal, :size_t,
+             :retriable, :size_t,
+             :txn_requires_abort, :size_t
     end
 
     attach_function :rd_kafka_group_result_error, [:pointer], NativeError.by_ref # rd_kafka_group_result_t* => rd_kafka_error_t*

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -454,9 +454,9 @@ module Rdkafka
     class NativeError < FFI::Struct # rd_kafka_error_t
       layout :code, :int32,
              :errstr, :pointer,
-             :fatal, :size_t,
-             :retriable, :size_t,
-             :txn_requires_abort, :size_t
+             :fatal, :u_int8_t,
+             :retriable, :u_int8_t,
+             :txn_requires_abort, :u_int8_t
     end
 
     attach_function :rd_kafka_group_result_error, [:pointer], NativeError.by_ref # rd_kafka_group_result_t* => rd_kafka_error_t*


### PR DESCRIPTION
fix for https://github.com/karafka/rdkafka-ruby/issues/364