### PR TITLE
Lazy start background logger thread when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.14.10 (Unreleased)
+- [Fix] Background logger stops working after forking causing memory leaks (mensfeld).
+
 ## 0.14.9 (2024-01-29)
 - [Fix] Partition cache caches invalid `nil` result for `PARTITIONS_COUNT_TTL`.
 - [Enhancement] Report `-1` instead of `nil` in case `partition_count` failure.

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -147,6 +147,8 @@ module Rdkafka
                  else
                    Logger::UNKNOWN
                  end
+
+      Rdkafka::Config.ensure_log_thread
       Rdkafka::Config.log_queue << [severity, "rdkafka: #{line}"]
     end
 

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -15,19 +15,36 @@ module Rdkafka
     @@opaques = ObjectSpace::WeakMap.new
     # @private
     @@log_queue = Queue.new
-
-    Thread.start do
-      loop do
-        severity, msg = @@log_queue.pop
-        @@logger.add(severity, msg)
-      end
-    end
+    # @private
+    # We memoize thread on the first log flush
+    # This allows us also to restart logger thread on forks
+    @@log_thread = nil
+    # @private
+    @@log_mutex = Mutex.new
 
     # Returns the current logger, by default this is a logger to stdout.
     #
     # @return [Logger]
     def self.logger
       @@logger
+    end
+
+    # Makes sure that there is a thread for consuming logs
+    # We do not spawn thread immediately and we need to check if it operates to support forking
+    def self.ensure_log_thread
+      return if @@log_thread && @@log_thread.alive?
+
+      @@log_mutex.synchronize do
+        # Restart if dead (fork, crash)
+        @@log_thread = nil if @@log_thread && !@@log_thread.alive?
+
+        @@log_thread ||= Thread.start do
+          loop do
+            severity, msg = @@log_queue.pop
+            @@logger.add(severity, msg)
+          end
+        end
+      end
     end
 
     # Returns a queue whose contents will be passed to the configured logger. Each entry

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.14.9"
+  VERSION = "0.14.10"
   LIBRDKAFKA_VERSION = "2.3.0"
   LIBRDKAFKA_SOURCE_SHA256 = "2d49c35c77eeb3d42fa61c43757fcbb6a206daa560247154e60642bcdcc14d12"
 end

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -31,6 +31,23 @@ describe Rdkafka::Config do
 
       expect(log.string).to include "FATAL -- : I love testing"
     end
+
+    it "expect to start new logger thread after fork and work" do
+      reader, writer = IO.pipe
+
+      pid = fork do
+        $stdout.reopen(writer)
+        reader.close
+        producer = rdkafka_producer_config(debug: 'all').producer
+        writer.close
+        producer.close
+      end
+
+      writer.close
+      output = reader.read
+      Process.wait(pid)
+      expect(output.split("\n").size).to be > 50
+    end
   end
 
   context "statistics callback" do


### PR DESCRIPTION
ref https://github.com/karafka/rdkafka-ruby/issues/407

will backport to rdkafka-ruby as well soon