### PR TITLE
[Rakefile] Use new fork location

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -25,7 +25,7 @@ task :default => :clean do
     releases = File.expand_path(File.join(File.dirname(__FILE__), '../dist'))
 
     recipe.files << {
-      :url => "file://#{releases}/librdkafka_#{Rdkafka::LIBRDKAFKA_VERSION}.tar.gz",
+      :url => "https://codeload.github.com/confluentinc/librdkafka/tar.gz/v#{Rdkafka::LIBRDKAFKA_VERSION}",
       :sha256 => Rdkafka::LIBRDKAFKA_SOURCE_SHA256
     }
     recipe.configure_options = ["--host=#{recipe.host}"]


### PR DESCRIPTION
The https://github.com/edenhill/librdkafka for a while has been redirecting to https://github.com/confluentinc/librdkafka, but as of today (2024-07-10), it seemed to stop redirecting to the new repo.

I had been looking at this `Rakefile` a bunch recently (as of yesterday) to help debug co-worker's install of this gem, and this was where it was redirecting to.

The repo seems to have been updated around the time of the 2.2.0 release:

https://github.com/confluentinc/librdkafka/commit/49f05db36e5bff78e856e33da951a5f998f9d55b
