### PR TITLE
Update ext/README.md to reflect dist/ changes

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -9,8 +9,8 @@ To update the `librdkafka` version follow the following steps:
   version number and asset checksum for `tar.gz`.
 * Change the version in `lib/rdkafka/version.rb`
 * Change the `sha256` in `lib/rdkafka/version.rb`
-* Download the newest version, place it in `dist/`, and call it
-  `"librdkafka_v#{version_number}.tar.gz"`
+* Run `bundle exec rake dist:download` in the `ext` directory to download the
+  new release and place it in the `dist/` for you
 * Run `bundle exec rake` in the `ext` directory to build the new version
 * Run `docker-compose pull` in the main gem directory to ensure the docker
   images used by the tests and run `docker-compose up`

--- a/ext/README.md
+++ b/ext/README.md
@@ -1,7 +1,7 @@
 # Ext
 
-This gem depends on the `librdkafka` C library. It is downloaded when
-this gem is installed.
+This gem depends on the `librdkafka` C library. It is downloaded, stored in
+`dist/` directory, and checked into source control.
 
 To update the `librdkafka` version follow the following steps:
 
@@ -9,8 +9,9 @@ To update the `librdkafka` version follow the following steps:
   version number and asset checksum for `tar.gz`.
 * Change the version in `lib/rdkafka/version.rb`
 * Change the `sha256` in `lib/rdkafka/version.rb`
-* Run `bundle exec rake` in the `ext` directory to download and build
-  the new version
+* Download the newest version, place it in `dist/`, and call it
+  `"librdkafka_v#{version_number}.tar.gz"`
+* Run `bundle exec rake` in the `ext` directory to build the new version
 * Run `docker-compose pull` in the main gem directory to ensure the docker
   images used by the tests and run `docker-compose up`
 * Finally, run `bundle exec rspec` in the main gem directory to execute

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path('../../lib/rdkafka/version', __FILE__)
+require "digest"
 require "fileutils"
 require "open-uri"
 
@@ -69,6 +70,42 @@ task :clean do
   FileUtils.rm_f File.join(File.dirname(__FILE__), "librdkafka.so")
   FileUtils.rm_rf File.join(File.dirname(__FILE__), "ports")
   FileUtils.rm_rf File.join(File.dirname(__FILE__), "tmp")
+end
+
+namespace :dist do
+  task :dir do
+    ENV["RDKAFKA_DIST_PATH"] ||= File.expand_path(File.join(File.dirname(__FILE__), '..', 'dist'))
+  end
+
+  task :file => "dist:dir" do
+    ENV["RDKAFKA_DIST_FILE"] ||= File.join(ENV["RDKAFKA_DIST_PATH"], "librdkafka_#{Rdkafka::LIBRDKAFKA_VERSION}.tar.gz")
+  end
+
+  task :clean => "dist:file" do
+    Dir.glob(File.join("#{ENV['RDKAFKA_DIST_PATH']}", "*")).each do |filename|
+      next if filename.include? ENV["RDKAFKA_DIST_FILE"]
+
+      FileUtils.rm_rf filename
+    end
+  end
+
+  task :download => "dist:file" do
+    version = Rdkafka::LIBRDKAFKA_VERSION
+    librdkafka_download = "https://codeload.github.com/confluentinc/librdkafka/tar.gz/v#{version}"
+
+    URI.open(librdkafka_download) do |file|
+      filename = ENV["RDKAFKA_DIST_FILE"]
+      data     = file.read
+
+      if Digest::SHA256.hexdigest(data) != Rdkafka::LIBRDKAFKA_SOURCE_SHA256
+        raise "SHA256 does not match downloaded file"
+      end
+
+      File.write(filename, data)
+    end
+  end
+
+  task :update => %w[dist:download dist:clean]
 end
 
 namespace :build do

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -78,7 +78,7 @@ namespace :build do
     version = "git-#{ref}"
 
     recipe = MiniPortile.new("librdkafka", version)
-    recipe.files << "https://github.com/edenhill/librdkafka/archive/#{ref}.tar.gz"
+    recipe.files << "https://github.com/confluentinc/librdkafka/archive/#{ref}.tar.gz"
     recipe.configure_options = ["--host=#{recipe.host}","--enable-static", "--enable-zstd"]
     recipe.cook
 


### PR DESCRIPTION
Does the following:

* Updates the `ext/README.md` with updated instructions
* Updates a `edenhill/librdkafka` reference to `confluentinc/librdkafka`
* As an new rake tasks to automate some of the steps
  - And updating the `ext/README.md` again to use this

The last commit is entirely optional, but providing it as an option to remove some human error, but am happy to `git rebase` that commit out of this PR since it is a bit extra..