### PR TITLE
Support ability to release patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rdkafka Changelog
 
+## 0.17.1 (Unreleased)
+- [Enhancement] Support ability to release patches to librdkafka.
+- [Patch] Patch cooperative-sticky assignments in librdkafka.
+
 ## 0.17.0 (2024-07-21)
 - [Enhancement] Bump librdkafka to 2.5.0
 

--- a/dist/patches/rdkafka_sticky_assignor.c.patch
+++ b/dist/patches/rdkafka_sticky_assignor.c.patch
@@ -1,5 +1,6 @@
 # This patch is released under the 2-clause BSD license, same as librdkafka
-# 
+# Fixes: https://github.com/confluentinc/librdkafka/issues/4783
+#
 --- librdkafka_2.5.0/src/rdkafka_sticky_assignor.c	2024-07-08 09:47:43.000000000 +0200
 +++ librdkafka_2.5.0/src/rdkafka_sticky_assignor.c	2024-07-30 09:44:38.529759640 +0200
 @@ -769,7 +769,7 @@

--- a/dist/patches/rdkafka_sticky_assignor.c.patch
+++ b/dist/patches/rdkafka_sticky_assignor.c.patch
@@ -1,0 +1,25 @@
+# This patch is released under the 2-clause BSD license, same as librdkafka
+# 
+--- librdkafka_2.5.0/src/rdkafka_sticky_assignor.c	2024-07-08 09:47:43.000000000 +0200
++++ librdkafka_2.5.0/src/rdkafka_sticky_assignor.c	2024-07-30 09:44:38.529759640 +0200
+@@ -769,7 +769,7 @@
+         const rd_kafka_topic_partition_list_t *partitions;
+         const char *consumer;
+         const rd_map_elem_t *elem;
+-        int i;
++        int i, j;
+ 
+         /* The assignment is balanced if minimum and maximum numbers of
+          * partitions assigned to consumers differ by at most one. */
+@@ -836,9 +836,9 @@
+ 
+                 /* Otherwise make sure it can't get any more partitions */
+ 
+-                for (i = 0; i < potentialTopicPartitions->cnt; i++) {
++                for (j = 0; j < potentialTopicPartitions->cnt; j++) {
+                         const rd_kafka_topic_partition_t *partition =
+-                            &potentialTopicPartitions->elems[i];
++                            &potentialTopicPartitions->elems[j];
+                         const char *otherConsumer;
+                         int otherConsumerPartitionCount;
+ 

--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -31,6 +31,8 @@ task :default => :clean do
     }
     recipe.configure_options = ["--host=#{recipe.host}"]
 
+    recipe.patch_files = Dir[File.join(releases, 'patches', "*.patch")].sort
+
     # Disable using libc regex engine in favor of the embedded one
     # The default regex engine of librdkafka does not always work exactly as most of the users
     # would expect, hence this flag allows for changing it to the other one
@@ -117,6 +119,7 @@ namespace :build do
     recipe = MiniPortile.new("librdkafka", version)
     recipe.files << "https://github.com/confluentinc/librdkafka/archive/#{ref}.tar.gz"
     recipe.configure_options = ["--host=#{recipe.host}","--enable-static", "--enable-zstd"]
+    recipe.patch_files = Dir[File.join(releases, 'patches', "*.patch")].sort
     recipe.cook
 
     ext = recipe.host.include?("darwin") ? "dylib" : "so"

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.17.0"
+  VERSION = "0.17.1"
   LIBRDKAFKA_VERSION = "2.5.0"
   LIBRDKAFKA_SOURCE_SHA256 = "3dc62de731fd516dfb1032861d9a580d4d0b5b0856beb0f185d06df8e6c26259"
 end


### PR DESCRIPTION
This PR ships ability to patch librdkafka plus sticky assignor patch.

It is not the first time that we (Ruby) has specific needs or there is an issue that can be solved with a simple patch. We should be able not to wait on critical things.
