### PR TITLE
support rk topic partition details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.17.2 (Unreleased)
+- [Enhancement] Support returning `#details` for errors that do have topic/partition related extra info.
+
 ## 0.17.1 (2024-08-01)
 - [Enhancement] Support ability to release patches to librdkafka.
 - [Patch] Patch cooperative-sticky assignments in librdkafka.

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.17.1"
+  VERSION = "0.17.2"
   LIBRDKAFKA_VERSION = "2.5.0"
   LIBRDKAFKA_SOURCE_SHA256 = "3dc62de731fd516dfb1032861d9a580d4d0b5b0856beb0f185d06df8e6c26259"
 end

--- a/spec/rdkafka/error_spec.rb
+++ b/spec/rdkafka/error_spec.rb
@@ -11,6 +11,12 @@ describe Rdkafka::RdkafkaError do
     expect(Rdkafka::RdkafkaError.new(10, "message prefix").message_prefix).to eq "message prefix"
   end
 
+  it "should have empty frozen details by default" do
+    error = Rdkafka::RdkafkaError.new(10, "message prefix")
+    expect(error.details).to eq({})
+    expect(error.details).to be_frozen
+  end
+
   it "should create an error with a broker message" do
     expect(Rdkafka::RdkafkaError.new(10, broker_message: "broker message").broker_message).to eq "broker message"
   end


### PR DESCRIPTION
This PR extracts metadata details from certain types of rdkafka errors (when available).