### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -360,7 +360,7 @@ module Rdkafka
         partitioner_name = @topics_configs.dig(topic, topic_config_hash, :partitioner) || @partitioner_name
 
         # If the topic is not present, set to -1
-        partition = Rdkafka::Bindings.partitioner(partition_key, partition_count, @partitioner_name) if partition_count.positive?
+        partition = Rdkafka::Bindings.partitioner(partition_key, partition_count, partitioner_name) if partition_count.positive?
       end
 
       # If partition is nil, use -1 to let librdafka set the partition randomly or


### PR DESCRIPTION
This is a follow-up to these [changes](https://github.com/karafka/karafka-rdkafka/commit/6b2a787748e8e3e557e061c0df952ccea687b770#diff-c51ca73d28c0b67d76f94a90d394790dea7f7d92a8624bea055749f29b745c37). Variable `partitioner_name` created but never used, so this PR should fix it.