### PR TITLE
revert auto-require on macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.18.1 (2024-12-04)
+- [Fix] Do not run `Rdkafka::Bindings.rd_kafka_global_init` on require to prevent some of macos versions from hanging on Puma fork.
+
 ## 0.18.0 (2024-11-26)
 - **[Breaking]** Drop Ruby 3.0 support
 - [Enhancement] Bump librdkafka to 2.6.1

--- a/lib/rdkafka.rb
+++ b/lib/rdkafka.rb
@@ -49,5 +49,3 @@ require "rdkafka/producer/delivery_report"
 # Main Rdkafka namespace of this gem
 module Rdkafka
 end
-
-Rdkafka::Bindings.rd_kafka_global_init

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.18.0"
+  VERSION = "0.18.1"
   LIBRDKAFKA_VERSION = "2.6.1"
   LIBRDKAFKA_SOURCE_SHA256 = "0ddf205ad8d36af0bc72a2fec20639ea02e1d583e353163bf7f4683d949e901b"
 end


### PR DESCRIPTION
This auto-require of patch was reported as causing some issues on macos (some versions). Before we can dive deeper into it I will revert it not to cause problems.