### PR TITLE
expand build matrix for mini portile

### DIFF
--- a/.github/workflows/ci_linux_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_x86_64_gnu.yml
@@ -104,16 +104,8 @@ jobs:
         ubuntu-version: ['22.04', '24.04']
         include:
           - ruby: '3.4'
-            ubuntu-version: '22.04'
-            coverage: 'true'
-          - ruby: '3.4'
-            ubuntu-version: '24.04'
             coverage: 'true'
           - ruby: 'jruby-10.0'
-            ubuntu-version: '22.04'
-            continue-on-error: true
-          - ruby: 'jruby-10.0'
-            ubuntu-version: '24.04'
             continue-on-error: true
     runs-on: ubuntu-${{ matrix.ubuntu-version }}
     steps:

--- a/.github/workflows/ci_linux_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_x86_64_gnu.yml
@@ -1,3 +1,37 @@
+# CI Strategy: Comprehensive Testing of Build and Precompiled Flows
+#
+# This workflow tests both compilation-from-source and precompiled binary distribution
+# strategies across multiple Ubuntu and Ruby versions to ensure broad compatibility and
+# reliability.
+#
+# WHY WE TEST BOTH UBUNTU 22.04 AND 24.04:
+# - Different system library versions (OpenSSL, zlib, libsasl2, libzstd, etc.)
+# - Different GCC compiler versions that affect native extension compilation
+# - Different glibc versions that can impact binary compatibility
+# - Real-world deployment scenarios where users run on various Ubuntu LTS versions
+# - Different Ruby versions
+#
+# COMPILATION FLOW (build_install + specs_install):
+# - Tests that librdkafka compiles correctly from source on each Ubuntu version
+# - Validates that mini_portile2 can successfully build native dependencies
+# - Ensures Ruby native extensions link properly with system libraries
+# - Verifies that the same codebase works across different toolchain versions
+#
+# PRECOMPILED FLOW (build_precompiled + specs_precompiled):
+# - Tests our precompiled static libraries work on different Ubuntu versions
+# - Validates that statically-linked binaries are truly portable across environments
+# - Ensures precompiled libraries don't have unexpected system dependencies
+# - Verifies that removing build tools doesn't break precompiled binary usage
+#
+# ARTIFACT ISOLATION:
+# - Each Ubuntu version gets separate artifacts (rdkafka-built-gem-22.04, etc.)
+# - Prevents cross-contamination of OS-specific compiled extensions
+# - Ensures test accuracy by matching build and test environments
+#
+# This comprehensive approach catches issues that single-platform testing would miss,
+# such as system library incompatibilities, compiler-specific bugs, or static linking
+# problems that only manifest on specific Ubuntu versions.
+
 name: CI Linux x86_64 GNU
 
 concurrency:
@@ -22,7 +56,10 @@ env:
 jobs:
   build_install:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ubuntu-version: ['22.04', '24.04']
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -43,7 +80,7 @@ jobs:
       - name: Upload built gem and bundle
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: rdkafka-built-gem
+          name: rdkafka-built-gem-${{ matrix.ubuntu-version }}
           path: |
             vendor/bundle/
             .bundle/
@@ -53,7 +90,6 @@ jobs:
 
   specs_install:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
     needs: build_install
     strategy:
       fail-fast: false
@@ -65,11 +101,21 @@ jobs:
           - '3.2'
           - '3.1'
           - 'jruby-10.0'
+        ubuntu-version: ['22.04', '24.04']
         include:
           - ruby: '3.4'
+            ubuntu-version: '22.04'
+            coverage: 'true'
+          - ruby: '3.4'
+            ubuntu-version: '24.04'
             coverage: 'true'
           - ruby: 'jruby-10.0'
+            ubuntu-version: '22.04'
             continue-on-error: true
+          - ruby: 'jruby-10.0'
+            ubuntu-version: '24.04'
+            continue-on-error: true
+    runs-on: ubuntu-${{ matrix.ubuntu-version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -77,7 +123,7 @@ jobs:
       - name: Download built gem
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: rdkafka-built-gem
+          name: rdkafka-built-gem-${{ matrix.ubuntu-version }}
           path: ./
       - name: Set up Ruby
         uses: ruby/setup-ruby@a4effe49ee8ee5b8b5091268c473a4628afb5651 # v1.245.0
@@ -124,7 +170,10 @@ jobs:
 
   build_precompiled:
     timeout-minutes: 30
-    runs-on: ubuntu-22.04
+    # We precompile on older Ubuntu and check compatibility by running specs since we aim to
+    # release only one precompiled version for all supported Ubuntu versions
+    # This is why we do not want Renovate to update it automatically
+    runs-on: ubuntu-22.04 # renovate: ignore
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.20.1 (2025-07-17)
+- [Fix] Support Ubuntu `22.04` and older Alpine precompiled versions
+
 ## 0.20.0 (2025-07-17)
 - **[Feature]** Add precompiled `x86_64-linux-gnu` setup.
 - **[Feature]** Add precompiled `x86_64-linux-musl` setup.

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  VERSION = "0.20.0"
+  VERSION = "0.20.1"
   LIBRDKAFKA_VERSION = "2.8.0"
   LIBRDKAFKA_SOURCE_SHA256 = "5bd1c46f63265f31c6bfcedcde78703f77d28238eadf23821c2b43fc30be3e25"
 end


### PR DESCRIPTION
This PR expands the build test matrix to cover all ubuntu versions for precompilation as well as on-install build flows.