### PR TITLE
Test end-to-end against SSL

### DIFF
--- a/.github/workflows/ci_linux_aarch64_gnu.yml
+++ b/.github/workflows/ci_linux_aarch64_gnu.yml
@@ -84,7 +84,8 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d
+          ./ext/generate-ssl-certs.sh
+          docker compose -f docker-compose-ssl.yml up -d
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -117,10 +118,19 @@ jobs:
           set -e
           cd ext && bundle exec rake
           cd ..
-      - name: Run all specs
+      - name: Run all specs in PLAINTEXT
         env:
           GITHUB_COVERAGE: ${{matrix.coverage}}
           RDKAFKA_EXT_PATH: ${{ github.workspace }}/ext
+        continue-on-error: ${{ matrix.continue-on-error || false }}
+        run: |
+          bundle exec rspec
+
+      - name: Run all specs specs in SSL
+        env:
+          GITHUB_COVERAGE: ${{matrix.coverage}}
+          RDKAFKA_EXT_PATH: ${{ github.workspace }}/ext
+          KAFKA_SSL: "1"
         continue-on-error: ${{ matrix.continue-on-error || false }}
         run: |
           bundle exec rspec
@@ -215,7 +225,8 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d
+          ./ext/generate-ssl-certs.sh
+          docker compose -f docker-compose-ssl.yml up -d
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -263,9 +274,17 @@ jobs:
           echo "Build dependencies removal completed"
           echo "Remaining build tools:"
           which gcc g++ make 2>/dev/null || echo "No build tools found in PATH (good!)"
-      - name: Run specs with precompiled library
+      - name: Run specs with precompiled library and PLAINTEXT
         env:
           GITHUB_COVERAGE: ${{ matrix.coverage }}
           RDKAFKA_EXT_PATH: ${{ github.workspace }}/ext
+        run: |
+          bundle exec rspec
+
+      - name: Run specs with precompiled library and SSL
+        env:
+          GITHUB_COVERAGE: ${{matrix.coverage}}
+          RDKAFKA_EXT_PATH: ${{ github.workspace }}/ext
+          KAFKA_SSL: "1"
         run: |
           bundle exec rspec

--- a/.github/workflows/ci_linux_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_x86_64_gnu.yml
@@ -84,7 +84,8 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d
+          ./ext/generate-ssl-certs.sh
+          docker compose -f docker-compose-ssl.yml up -d
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -215,7 +216,8 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d
+          ./ext/generate-ssl-certs.sh
+          docker compose -f docker-compose-ssl.yml up -d
           echo "Waiting for Kafka to be ready..."
 
           sleep 10

--- a/.github/workflows/ci_linux_x86_64_musl.yml
+++ b/.github/workflows/ci_linux_x86_64_musl.yml
@@ -73,7 +73,8 @@ jobs:
 
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d
+          ./ext/generate-ssl-certs.sh
+          docker compose -f docker-compose-ssl.yml up -d
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -168,7 +169,8 @@ jobs:
           path: ext/
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose up -d
+          ./ext/generate-ssl-certs.sh
+          docker compose -f docker-compose-ssl.yml up -d
           echo "Waiting for Kafka to be ready..."
           sleep 10
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 vendor
 .idea/
 out/
+ssl/

--- a/docker-compose-ssl.yml
+++ b/docker-compose-ssl.yml
@@ -1,0 +1,35 @@
+services:
+  kafka:
+    container_name: kafka
+    image: confluentinc/cp-kafka:8.0.0
+    ports:
+      - 9092:9092 # Support PLAINTEXT so we can run one docker setup for SSL and PLAINTEXT
+      - 9093:9093
+    volumes:
+      - ./ssl:/etc/kafka/secrets
+    environment:
+      CLUSTER_ID: kafka-docker-cluster-1
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENERS: PLAINTEXT://:9092,SSL://:9093,CONTROLLER://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,SSL:SSL
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092,SSL://127.0.0.1:9093
+      KAFKA_BROKER_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9094
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+      KAFKA_AUTHORIZER_CLASS_NAME: org.apache.kafka.metadata.authorizer.StandardAuthorizer
+
+      # SSL Configuration
+      KAFKA_SSL_KEYSTORE_FILENAME: kafka.server.keystore.jks
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: kafka_keystore_creds
+      KAFKA_SSL_KEY_CREDENTIALS: kafka_ssl_key_creds
+      KAFKA_SSL_TRUSTSTORE_FILENAME: kafka.server.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: kafka_truststore_creds
+      KAFKA_SSL_CLIENT_AUTH: none
+      KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM: ""

--- a/ext/generate-ssl-certs.sh
+++ b/ext/generate-ssl-certs.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+#==============================================================================
+# Kafka SSL Certificate Generator
+#==============================================================================
+#
+# DESCRIPTION:
+#   Generates SSL certificates for testing Kafka with SSL/TLS encryption.
+#   Creates both Java KeyStore (JKS) files for Kafka server and PEM files
+#   for client applications like rdkafka.
+#
+# PURPOSE:
+#   - Test SSL connectivity between Kafka clients and brokers
+#   - Validate rdkafka SSL integration
+#   - Enable encrypted communication for development/testing environments
+#
+# USAGE:
+#   ./ext/generate-ssl-certs.sh
+#   docker compose -f docker-compose-ssl.yml up
+#
+# REQUIREMENTS:
+#   - OpenSSL (for certificate generation)
+#   - Java keytool (usually included with JDK/JRE)
+#   - Write permissions in current directory
+#
+# OUTPUT FILES (created in ./ssl/ directory):
+#   ├── kafka.server.keystore.jks    # Kafka server's private key and certificate
+#   ├── kafka.server.truststore.jks  # Trusted CA certificates for Kafka
+#   ├── kafka_keystore_creds         # Password file for keystore
+#   ├── kafka_truststore_creds       # Password file for truststore
+#   ├── kafka_ssl_key_creds          # Password file for SSL keys
+#   ├── ca-cert                      # CA certificate (for rdkafka clients)
+#   └── ca-cert.pem                  # CA certificate in PEM format
+#
+# CONFIGURATION:
+#   - Certificate validity: 365 days
+#   - Password: "confluent" (all certificates use same password for simplicity)
+#   - Subject: CN=localhost (suitable for local testing)
+#   - CA Subject: CN=localhost-ca
+#
+# DOCKER COMPOSE INTEGRATION:
+#   Use with docker-compose-ssl.yml that mounts ./ssl directory to
+#   /etc/kafka/secrets inside the Kafka container.
+#
+# RDKAFKA CLIENT CONFIGURATION:
+#   security.protocol=SSL
+#   ssl.ca.location=./ssl/ca-cert
+#   ssl.endpoint.identification.algorithm=none  # For localhost testing
+#
+# NOTES:
+#   - Safe to run multiple times (cleans up existing files)
+#   - Certificates are self-signed and suitable for testing only
+#   - For production, use certificates signed by a trusted CA
+#   - All passwords are set to "confluent" for simplicity
+#
+#==============================================================================
+
+# Create ssl directory and clean up any existing files
+mkdir -p ssl
+cd ssl
+
+# Clean up existing files
+rm -f kafka.server.keystore.jks kafka.server.truststore.jks
+rm -f kafka_keystore_creds kafka_truststore_creds kafka_ssl_key_creds
+rm -f ca-key ca-cert cert-file cert-signed ca-cert.srl ca-cert.pem
+
+echo "Cleaned up existing SSL files..."
+
+# Set variables
+VALIDITY_DAYS=365
+PASSWORD="confluent"  # Use a simpler, well-known password
+DNAME="CN=localhost,OU=Test,O=Test,L=Test,ST=Test,C=US"
+
+# Create password files (all same password for simplicity)
+echo "$PASSWORD" > kafka_keystore_creds
+echo "$PASSWORD" > kafka_truststore_creds
+echo "$PASSWORD" > kafka_ssl_key_creds
+
+# Step 1: Generate CA key and certificate
+openssl req -new -x509 -keyout ca-key -out ca-cert -days $VALIDITY_DAYS -subj "/CN=localhost-ca/OU=Test/O=Test/L=Test/S=Test/C=US" -passin pass:$PASSWORD -passout pass:$PASSWORD
+
+# Step 2: Create truststore and import the CA certificate
+keytool -keystore kafka.server.truststore.jks -alias CARoot -import -file ca-cert -storepass $PASSWORD -keypass $PASSWORD -noprompt
+
+# Step 3: Create keystore
+keytool -keystore kafka.server.keystore.jks -alias localhost -validity $VALIDITY_DAYS -genkey -keyalg RSA -dname "$DNAME" -storepass $PASSWORD -keypass $PASSWORD
+
+# Step 4: Create certificate signing request
+keytool -keystore kafka.server.keystore.jks -alias localhost -certreq -file cert-file -storepass $PASSWORD -keypass $PASSWORD
+
+# Step 5: Sign the certificate with the CA
+openssl x509 -req -CA ca-cert -CAkey ca-key -in cert-file -out cert-signed -days $VALIDITY_DAYS -CAcreateserial -passin pass:$PASSWORD
+
+# Step 6: Import CA certificate into keystore
+keytool -keystore kafka.server.keystore.jks -alias CARoot -import -file ca-cert -storepass $PASSWORD -keypass $PASSWORD -noprompt
+
+# Step 7: Import signed certificate into keystore
+keytool -keystore kafka.server.keystore.jks -alias localhost -import -file cert-signed -storepass $PASSWORD -keypass $PASSWORD -noprompt
+
+# Export CA certificate to PEM format for rdkafka
+cp ca-cert ca-cert.pem
+
+# Clean up intermediate files (but keep ca-cert.pem for rdkafka)
+rm ca-key cert-file cert-signed
+
+echo "SSL certificates generated successfully!"
+echo "Password: $PASSWORD"
+echo ""
+echo "For rdkafka, use ca-cert.pem or ca-cert files"

--- a/spec/rdkafka/metadata_spec.rb
+++ b/spec/rdkafka/metadata_spec.rb
@@ -31,7 +31,7 @@ describe Rdkafka::Metadata do
         expect(subject.brokers.length).to eq(1)
         expect(subject.brokers[0][:broker_id]).to eq(1)
         expect(%w[127.0.0.1 localhost]).to include(subject.brokers[0][:broker_name])
-        expect(subject.brokers[0][:broker_port]).to eq(9092)
+        expect(subject.brokers[0][:broker_port]).to eq(rdkafka_base_config[:'bootstrap.servers'].split(':').last.to_i)
       end
 
       it "#topics returns data on our test topic" do
@@ -54,7 +54,7 @@ describe Rdkafka::Metadata do
       expect(subject.brokers.length).to eq(1)
       expect(subject.brokers[0][:broker_id]).to eq(1)
       expect(%w[127.0.0.1 localhost]).to include(subject.brokers[0][:broker_name])
-      expect(subject.brokers[0][:broker_port]).to eq(9092)
+      expect(subject.brokers[0][:broker_port]).to eq(rdkafka_base_config[:'bootstrap.servers'].split(':').last.to_i)
     end
 
     it "#topics returns data about all of our test topics" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,12 +28,25 @@ require "timeout"
 require "securerandom"
 
 def rdkafka_base_config
-  {
-    :"bootstrap.servers" => "localhost:9092",
-    # Display statistics and refresh often just to cover those in specs
-    :'statistics.interval.ms' => 1_000,
-    :'topic.metadata.refresh.interval.ms' => 1_000
-  }
+  if ENV['KAFKA_SSL_ENABLED'] == 'true'
+    {
+      :"bootstrap.servers" => "localhost:9093",
+      # Display statistics and refresh often just to cover those in specs
+      :'statistics.interval.ms' => 1_000,
+      :'topic.metadata.refresh.interval.ms' => 1_000,
+      # SSL Configuration
+      :'security.protocol' => 'SSL',
+      :'ssl.ca.location' => './ssl/ca-cert',
+      :'ssl.endpoint.identification.algorithm' => 'none'
+    }
+  else
+    {
+      :"bootstrap.servers" => "localhost:9092",
+      # Display statistics and refresh often just to cover those in specs
+      :'statistics.interval.ms' => 1_000,
+      :'topic.metadata.refresh.interval.ms' => 1_000
+    }
+  end
 end
 
 def rdkafka_config(config_overrides={})


### PR DESCRIPTION
There is a chance that on bookworm new openssl 3.0.17 broke librdkafka integration. To prevent this from not being visible asap this will add SSL tests and in a separate PR we will add bookworm (since used by users) as a separate CI platform for building and testing.
