### PR TITLE
lower os run frequency and add trixie

### DIFF
--- a/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
+++ b/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
@@ -43,7 +43,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 5 */3 * *'
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
+++ b/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
@@ -9,7 +9,7 @@
 # - SSL specs have been stable for 3+ years and rarely break due to code changes
 # - Integration specs test musl libc and Alpine package compatibility
 # - These tests catch regressions from external changes (OpenSSL updates, Alpine package updates)
-# - Running nightly prevents these slower tests from blocking PR velocity
+# - Running every 3 days to prevent these slower tests from blocking PR velocity
 # - Manual triggering allows testing workflow changes before they go into schedule
 #
 # SSL TESTING (specs_install + specs_precompiled):
@@ -27,7 +27,7 @@
 # - Tests both compilation and precompiled library compatibility on Alpine
 #
 # SCHEDULING STRATEGY:
-# - Runs nightly at 5 AM to catch system/library changes from Alpine base image updates
+# - Runs every 3 days at 5 AM to catch system/library changes from Alpine base image updates
 # - Triggers on workflow file changes to validate CI modifications
 # - Manual dispatch available for ad-hoc regression testing
 # - Separate artifact naming prevents interference with main CI

--- a/.github/workflows/ci_linux_debian_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu.yml
@@ -70,7 +70,6 @@ jobs:
           - 'trixie'
         include:
           - ruby: '3.4'
-            debian: 'trixie'
             coverage: 'true'
     runs-on: ubuntu-latest
     steps:
@@ -223,7 +222,6 @@ jobs:
           - 'trixie'
         include:
           - ruby: '3.4'
-            debian: 'trixie'
             coverage: 'true'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_linux_debian_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu.yml
@@ -4,27 +4,28 @@
 # strategies across multiple Debian and Ruby versions to ensure broad compatibility and
 # reliability.
 #
-# WHY WE TEST DEBIAN BOOKWORM:
+# WHY WE TEST DEBIAN BOOKWORM AND TRIXIE:
 # - Different system library versions (OpenSSL, zlib, libsasl2, libzstd, etc.)
 # - Different GCC compiler versions that affect native extension compilation
 # - Different glibc versions that can impact binary compatibility
-# - Real-world deployment scenarios where users run on Debian stable
+# - Real-world deployment scenarios where users run on Debian stable and testing
 # - Different Ruby versions
+# - Forward compatibility testing with Trixie (Debian testing/future stable)
 #
 # COMPILATION FLOW (build_install + specs_install):
-# - Tests that librdkafka compiles correctly from source on Debian
+# - Tests that librdkafka compiles correctly from source on both Debian versions
 # - Validates that mini_portile2 can successfully build native dependencies
 # - Ensures Ruby native extensions link properly with system libraries
 # - Verifies that the same codebase works across different toolchain versions
 #
 # PRECOMPILED FLOW (build_precompiled + specs_precompiled):
-# - Tests our precompiled static libraries work on Debian
+# - Tests our precompiled static libraries work on both Debian versions
 # - Validates that statically-linked binaries are truly portable across environments
 # - Ensures precompiled libraries don't have unexpected system dependencies
 # - Verifies that removing build tools doesn't break precompiled binary usage
 #
 # ARTIFACT ISOLATION:
-# - Debian gets separate artifacts (rdkafka-built-gem-debian, etc.)
+# - Debian gets separate artifacts (rdkafka-built-gem-debian-bookworm, etc.)
 # - Prevents cross-contamination of OS-specific compiled extensions
 # - Ensures test accuracy by matching build and test environments
 #
@@ -32,7 +33,7 @@
 # such as system library incompatibilities, compiler-specific bugs, or static linking
 # problems that only manifest on specific Debian versions.
 
-name: CI Linux Debian Bookworm x86_64 GNU
+name: CI Linux Debian Multi-Version x86_64 GNU
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -64,8 +65,12 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
+        debian:
+          - 'bookworm'
+          - 'trixie'
         include:
           - ruby: '3.4'
+            debian: 'bookworm'
             coverage: 'true'
     runs-on: ubuntu-latest
     steps:
@@ -95,7 +100,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -110,7 +115,7 @@ jobs:
             --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -131,7 +136,7 @@ jobs:
             -w /workspace \
             -e "GITHUB_COVERAGE=${{ matrix.coverage }}" \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -143,6 +148,12 @@ jobs:
 
   build_precompiled:
     timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        debian:
+          - 'bookworm'
+          - 'trixie'
     # We precompile on older Ubuntu and check compatibility by running specs since we aim to
     # release only one precompiled version for all supported Ubuntu versions
     # This is why we do not want Renovate to update it automatically
@@ -184,7 +195,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ext/build-tmp
-          key: build-tmp-${{ runner.os }}-${{ hashFiles('ext/*.sh', 'ext/Rakefile') }}-v2
+          key: build-tmp-${{ runner.os }}-${{ matrix.debian }}-${{ hashFiles('ext/*.sh', 'ext/Rakefile') }}-v2
       - name: Build precompiled librdkafka.so
         run: |
           cd ext
@@ -192,7 +203,7 @@ jobs:
       - name: Upload precompiled library
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: librdkafka-precompiled-linux
+          name: librdkafka-precompiled-linux-${{ matrix.debian }}
           path: ext/
           retention-days: 1
 
@@ -207,8 +218,12 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
+        debian:
+          - 'bookworm'
+          - 'trixie'
         include:
           - ruby: '3.4'
+            debian: 'bookworm'
             coverage: 'true'
 
     runs-on: ubuntu-latest
@@ -219,7 +234,7 @@ jobs:
       - name: Download precompiled library
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          name: librdkafka-precompiled-linux
+          name: librdkafka-precompiled-linux-${{ matrix.debian }}
           path: ext/
       - name: Start Kafka with Docker Compose
         run: |
@@ -244,7 +259,7 @@ jobs:
             -w /workspace \
             -e "GITHUB_COVERAGE=${{ matrix.coverage }}" \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get install -y git && \
               git config --global --add safe.directory /workspace && \

--- a/.github/workflows/ci_linux_debian_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu.yml
@@ -70,7 +70,7 @@ jobs:
           - 'trixie'
         include:
           - ruby: '3.4'
-            debian: 'bookworm'
+            debian: 'trixie'
             coverage: 'true'
     runs-on: ubuntu-latest
     steps:
@@ -223,7 +223,7 @@ jobs:
           - 'trixie'
         include:
           - ruby: '3.4'
-            debian: 'bookworm'
+            debian: 'trixie'
             coverage: 'true'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_linux_debian_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu.yml
@@ -68,6 +68,9 @@ jobs:
         debian:
           - 'bookworm'
           - 'trixie'
+        exclude:
+          - ruby: '3.1'
+            debian: 'trixie'
         include:
           - ruby: '3.4'
             coverage: 'true'
@@ -220,6 +223,9 @@ jobs:
         debian:
           - 'bookworm'
           - 'trixie'
+        exclude:
+          - ruby: '3.1'
+            debian: 'trixie'
         include:
           - ruby: '3.4'
             coverage: 'true'

--- a/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
@@ -9,7 +9,7 @@
 # - SSL specs have been stable for 3+ years and rarely break due to code changes
 # - Integration specs test OS library compatibility, which changes with system updates
 # - These tests catch regressions from external changes (OpenSSL updates, system libs)
-# - Running nightly prevents these slower tests from blocking PR velocity
+# - Running every 3 days to prevent these slower tests from blocking PR velocity
 # - Manual triggering allows testing workflow changes before they go into schedule
 #
 # SSL TESTING (specs_install + specs_precompiled):
@@ -27,7 +27,7 @@
 # - Tests both compilation and precompiled library compatibility
 #
 # SCHEDULING STRATEGY:
-# - Runs nightly at 3 AM to catch system/library changes from base image updates
+# - Runs every 3 days at 3 AM to catch system/library changes from base image updates
 # - Triggers on workflow file changes to validate CI modifications
 # - Manual dispatch available for ad-hoc regression testing
 # - Separate artifact naming prevents interference with main CI

--- a/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
@@ -12,9 +12,15 @@
 # - Running every 3 days to prevent these slower tests from blocking PR velocity
 # - Manual triggering allows testing workflow changes before they go into schedule
 #
+# WHY WE TEST DEBIAN BOOKWORM AND TRIXIE:
+# - Different OpenSSL versions and SSL library implementations
+# - Different system library versions that affect SSL handshakes and compatibility
+# - Forward compatibility testing with Trixie (Debian testing/future stable)
+# - Catching SSL regressions from package updates in both stable and testing
+#
 # SSL TESTING (specs_install + specs_precompiled):
 # - Tests SSL/TLS connectivity with Kafka using docker-compose-ssl.yml
-# - Validates certificate handling and SSL handshakes across Ruby versions
+# - Validates certificate handling and SSL handshakes across Ruby and Debian versions
 # - Ensures SSL works with both compiled-from-source and precompiled flows
 # - Catches OpenSSL version compatibility issues and SSL library regressions
 # - Tests real SSL scenarios that mirror production deployments
@@ -35,7 +41,7 @@
 # This approach ensures comprehensive coverage while keeping PR CI fast and focused
 # on code-related issues rather than infrastructure/system regressions.
 
-name: CI Linux Complementary Debian Bookworm x86_64 GNU
+name: CI Linux Complementary Debian Multi-Version x86_64 GNU
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -64,6 +70,12 @@ env:
 jobs:
   build_precompiled:
     timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        debian:
+          - 'bookworm'
+          - 'trixie'
     runs-on: ubuntu-22.04 # renovate: ignore
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -102,7 +114,7 @@ jobs:
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ext/build-tmp
-          key: build-tmp-${{ runner.os }}-${{ hashFiles('ext/*.sh', 'ext/Rakefile') }}-v2
+          key: build-tmp-complementary-${{ runner.os }}-${{ matrix.debian }}-${{ hashFiles('ext/*.sh', 'ext/Rakefile') }}-v2
       - name: Build precompiled librdkafka.so
         run: |
           cd ext
@@ -110,7 +122,7 @@ jobs:
       - name: Upload precompiled library
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: librdkafka-precompiled-linux-complementary
+          name: librdkafka-precompiled-linux-complementary-${{ matrix.debian }}
           path: ext/
           retention-days: 1
 
@@ -124,6 +136,12 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
+        debian:
+          - 'bookworm'
+          - 'trixie'
+        exclude:
+          - ruby: '3.1'
+            debian: 'trixie'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -153,7 +171,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -168,7 +186,7 @@ jobs:
             --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -189,7 +207,7 @@ jobs:
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
             -e "KAFKA_SSL_ENABLED=true" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -197,7 +215,7 @@ jobs:
               git config --global --add safe.directory /workspace && \
               bundle config set --local path vendor/bundle && \
               bundle install && \
-              echo "=== SSL Library Versions ===" && \
+              echo "=== SSL Library Versions (${{ matrix.debian }}) ===" && \
               openssl version && \
               dpkg -l | grep -E "(libssl|openssl)" && \
               echo "=== Running SSL Specs (Compiled) ===" && \
@@ -208,7 +226,7 @@ jobs:
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -216,12 +234,12 @@ jobs:
               git config --global --add safe.directory /workspace && \
               bundle config set --local path vendor/bundle && \
               bundle install && \
-              echo "=== OS Library Versions ===" && \
+              echo "=== OS Library Versions (${{ matrix.debian }}) ===" && \
               openssl version && \
               dpkg -l | grep -E "(libssl|libsasl|libzstd|zlib)" && \
               echo "=== Running Integration Specs (Compiled) ===" && \
               for file in $(ls spec/integrations/*_spec.rb); do \
-                echo "Running $file with Ruby ${{ matrix.ruby }}"; \
+                echo "Running $file with Ruby ${{ matrix.ruby }} on ${{ matrix.debian }}"; \
                 bundle exec ruby "$file" || exit 1; \
               done'
 
@@ -236,6 +254,12 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
+        debian:
+          - 'bookworm'
+          - 'trixie'
+        exclude:
+          - ruby: '3.1'
+            debian: 'trixie'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -244,7 +268,7 @@ jobs:
       - name: Download precompiled library
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          name: librdkafka-precompiled-linux-complementary
+          name: librdkafka-precompiled-linux-complementary-${{ matrix.debian }}
           path: ext/
 
       - name: Start Kafka with Docker Compose
@@ -272,13 +296,13 @@ jobs:
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
             -e "KAFKA_SSL_ENABLED=true" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get install -y git default-jdk && \
               git config --global --add safe.directory /workspace && \
               bundle config set --local path vendor/bundle && \
               bundle install && \
-              echo "=== SSL Library Versions ===" && \
+              echo "=== SSL Library Versions (${{ matrix.debian }}) ===" && \
               openssl version && \
               dpkg -l | grep -E "(libssl|openssl)" && \
               echo "=== Running SSL Specs (Precompiled) ===" && \
@@ -292,7 +316,7 @@ jobs:
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \
-            ruby:${{ matrix.ruby }}-bookworm \
+            ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
             sh -c 'apt-get update && \
               apt-get upgrade -y openssl libssl3 libssl-dev && \
               apt-get install -y git build-essential pkg-config \
@@ -300,11 +324,11 @@ jobs:
               git config --global --add safe.directory /workspace && \
               bundle config set --local path vendor/bundle && \
               bundle install && \
-              echo "=== OS Library Versions ===" && \
+              echo "=== OS Library Versions (${{ matrix.debian }}) ===" && \
               openssl version && \
               dpkg -l | grep -E "(libssl|libsasl|libzstd|zlib)" && \
               echo "=== Running Integration Specs (Precompiled) ===" && \
               for file in $(ls spec/integrations/*_spec.rb); do \
-                echo "Running $file with Ruby ${{ matrix.ruby }} (precompiled)"; \
+                echo "Running $file with Ruby ${{ matrix.ruby }} on ${{ matrix.debian }} (precompiled)"; \
                 bundle exec ruby "$file" || exit 1; \
               done'

--- a/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
@@ -43,7 +43,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 */3 * *'
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
@@ -28,7 +28,7 @@
 # - Cross-platform compatibility validation for aarch64 architecture
 #
 # SCHEDULING STRATEGY:
-# - Runs nightly at 3 AM to catch system/library changes from base image updates
+# - Runs nightly at 4 AM to catch system/library changes from base image updates
 # - Triggers on workflow file changes to validate CI modifications
 # - Manual dispatch available for ad-hoc regression testing
 # - Separate artifact naming prevents interference with main CI
@@ -44,7 +44,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 4 */3 * *'
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
@@ -11,7 +11,7 @@
 # - Integration specs test OS library compatibility, which changes with system updates
 # - ARM64 architecture has specific compilation and linking considerations
 # - These tests catch regressions from external changes (system libs, Ruby updates)
-# - Running nightly prevents these slower tests from blocking PR velocity
+# - Running every 3 days to prevent these slower tests from blocking PR velocity
 # - Manual triggering allows testing workflow changes before they go into schedule
 #
 # PRECOMPILED BINARY TESTING (build_precompiled + specs_precompiled):
@@ -28,7 +28,7 @@
 # - Cross-platform compatibility validation for aarch64 architecture
 #
 # SCHEDULING STRATEGY:
-# - Runs nightly at 4 AM to catch system/library changes from base image updates
+# - Runs every 3 days at 4 AM to catch system/library changes from base image updates
 # - Triggers on workflow file changes to validate CI modifications
 # - Manual dispatch available for ad-hoc regression testing
 # - Separate artifact naming prevents interference with main CI

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
@@ -43,7 +43,7 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 */3 * *'
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
@@ -10,7 +10,7 @@
 # - Edge Ruby versions (3.1, 3.5-preview, JRuby) need testing but shouldn't block PRs
 # - Integration specs test OS library compatibility, which changes with system updates
 # - These tests catch regressions from external changes (system libs, Ruby updates)
-# - Running nightly prevents these slower tests from blocking PR velocity
+# - Running every 3 days to prevent these slower tests from blocking PR velocity
 # - Manual triggering allows testing workflow changes before they go into schedule
 #
 # PRECOMPILED BINARY TESTING (build_precompiled + specs_precompiled):
@@ -27,7 +27,7 @@
 # - Cross-platform compatibility validation
 #
 # SCHEDULING STRATEGY:
-# - Runs nightly at 2 AM to catch system/library changes from base image updates
+# - Runs every 3 days at 2 AM to catch system/library changes from base image updates
 # - Triggers on workflow file changes to validate CI modifications
 # - Manual dispatch available for ad-hoc regression testing
 # - Separate artifact naming prevents interference with main CI


### PR DESCRIPTION
This PR adds trixie debian version alongside bookworm

it also moves the complementary CI to run every 3 days instead of every day so we do not abuse the github actions amount.