### PR TITLE
normalize topics in specs

### DIFF
--- a/spec/integrations/unregistered_scheme_file_spec.rb
+++ b/spec/integrations/unregistered_scheme_file_spec.rb
@@ -19,6 +19,7 @@ require 'socket'
 require 'openssl'
 require 'stringio'
 require 'logger'
+require 'securerandom'
 
 $stdout.sync = true
 

--- a/spec/integrations/unregistered_scheme_file_spec.rb
+++ b/spec/integrations/unregistered_scheme_file_spec.rb
@@ -89,7 +89,7 @@ config = Rdkafka::Config.new(
 begin
   consumer = config.consumer
   puts 'Consumer created, attempting to consume...'
-  consumer.subscribe('test-topic')
+  consumer.subscribe("it-#{SecureRandom.uuid}")
 
   # Try to poll for messages - this triggers SSL errors
   start_time = Time.now

--- a/spec/lib/rdkafka/admin/create_topic_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/create_topic_handle_spec.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
+require "spec_helper"
+
 describe Rdkafka::Admin::CreateTopicHandle do
   let(:response) { 0 }
+  let(:topic_name) { TestTopics.unique }
 
   subject do
     Rdkafka::Admin::CreateTopicHandle.new.tap do |handle|
       handle[:pending] = pending_handle
       handle[:response] = response
       handle[:error_string] = FFI::Pointer::NULL
-      handle[:result_name] = FFI::MemoryPointer.from_string("my-test-topic")
+      handle[:result_name] = FFI::MemoryPointer.from_string(topic_name)
     end
   end
 
@@ -28,14 +31,14 @@ describe Rdkafka::Admin::CreateTopicHandle do
         report = subject.wait
 
         expect(report.error_string).to eq(nil)
-        expect(report.result_name).to eq("my-test-topic")
+        expect(report.result_name).to eq(topic_name)
       end
 
       it "should wait without a timeout" do
         report = subject.wait(max_wait_timeout: nil)
 
         expect(report.error_string).to eq(nil)
-        expect(report.result_name).to eq("my-test-topic")
+        expect(report.result_name).to eq(topic_name)
       end
     end
   end

--- a/spec/lib/rdkafka/admin/delete_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_acl_handle_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DeleteAclHandle do
   let(:response) { Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR }
-  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
+  let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}

--- a/spec/lib/rdkafka/admin/delete_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_acl_handle_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DeleteAclHandle do
   let(:response) { Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR }
-  let(:resource_name)         {"acl-test-topic"}
+  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}

--- a/spec/lib/rdkafka/admin/delete_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_acl_report_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DeleteAclReport do
 
-  let(:resource_name)         {"acl-test-topic"}
+  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}
@@ -45,7 +45,7 @@ describe Rdkafka::Admin::DeleteAclReport do
     expect(subject.deleted_acls[0].matching_acl_resource_type).to eq(Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC)
   end
 
-  it "should get deleted acl resource name as acl-test-topic" do
+  it "should get deleted acl resource name" do
     expect(subject.deleted_acls[0].matching_acl_resource_name).to eq(resource_name)
   end
 

--- a/spec/lib/rdkafka/admin/delete_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_acl_report_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DeleteAclReport do
 
-  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
+  let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}

--- a/spec/lib/rdkafka/admin/delete_topic_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/delete_topic_handle_spec.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
+require "spec_helper"
+
 describe Rdkafka::Admin::DeleteTopicHandle do
   let(:response) { 0 }
+  let(:topic_name) { TestTopics.unique }
 
   subject do
     Rdkafka::Admin::DeleteTopicHandle.new.tap do |handle|
       handle[:pending] = pending_handle
       handle[:response] = response
       handle[:error_string] = FFI::Pointer::NULL
-      handle[:result_name] = FFI::MemoryPointer.from_string("my-test-topic")
+      handle[:result_name] = FFI::MemoryPointer.from_string(topic_name)
     end
   end
 
@@ -28,14 +31,14 @@ describe Rdkafka::Admin::DeleteTopicHandle do
         report = subject.wait
 
         expect(report.error_string).to eq(nil)
-        expect(report.result_name).to eq("my-test-topic")
+        expect(report.result_name).to eq(topic_name)
       end
 
       it "should wait without a timeout" do
         report = subject.wait(max_wait_timeout: nil)
 
         expect(report.error_string).to eq(nil)
-        expect(report.result_name).to eq("my-test-topic")
+        expect(report.result_name).to eq(topic_name)
       end
     end
   end

--- a/spec/lib/rdkafka/admin/describe_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/describe_acl_handle_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DescribeAclHandle do
   let(:response) { Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR }
-  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
+  let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}

--- a/spec/lib/rdkafka/admin/describe_acl_handle_spec.rb
+++ b/spec/lib/rdkafka/admin/describe_acl_handle_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DescribeAclHandle do
   let(:response) { Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR }
-  let(:resource_name)         {"acl-test-topic"}
+  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}
@@ -68,7 +68,7 @@ describe Rdkafka::Admin::DescribeAclHandle do
       it "should wait without a timeout" do
         report = subject.wait(max_wait_timeout: nil)
 
-        expect(report.acls[0].matching_acl_resource_name).to eq("acl-test-topic")
+        expect(report.acls[0].matching_acl_resource_name).to eq(resource_name)
       end
     end
   end

--- a/spec/lib/rdkafka/admin/describe_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/describe_acl_report_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DescribeAclReport do
 
-  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
+  let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}

--- a/spec/lib/rdkafka/admin/describe_acl_report_spec.rb
+++ b/spec/lib/rdkafka/admin/describe_acl_report_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe Rdkafka::Admin::DescribeAclReport do
 
-  let(:resource_name)         {"acl-test-topic"}
+  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}
@@ -46,7 +46,7 @@ describe Rdkafka::Admin::DescribeAclReport do
     expect(subject.acls[0].matching_acl_resource_type).to eq(Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC)
   end
 
-  it "should get matching acl resource name as acl-test-topic" do
+  it "should get matching acl resource name" do
     expect(subject.acls[0].matching_acl_resource_name).to eq(resource_name)
   end
 

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -21,9 +21,9 @@ describe Rdkafka::Admin do
   let(:topic_replication_factor) { 1 }
   let(:topic_config)             { {"cleanup.policy" => "compact", "min.cleanable.dirty.ratio" => 0.8} }
   let(:invalid_topic_config)     { {"cleeeeenup.policee" => "campact"} }
-  let(:group_name)               { TestTopics.unique(prefix: 'it-group') }
+  let(:group_name)               { TestTopics.unique }
 
-  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
+  let(:resource_name)         { TestTopics.unique }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}
@@ -514,7 +514,7 @@ describe Rdkafka::Admin do
   end
 
   describe "#ACL tests for topic resource" do
-    let(:non_existing_resource_name) { TestTopics.unique(prefix: 'it-non-existing') }
+    let(:non_existing_resource_name) { TestTopics.unique }
     before do
       #create topic for testing acl
       create_topic_handle = admin.create_topic(resource_name, topic_partition_count, topic_replication_factor)
@@ -564,12 +564,12 @@ describe Rdkafka::Admin do
 
       it "create acls and describe the newly created acls" do
         #create_acl
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
 
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
@@ -595,12 +595,12 @@ describe Rdkafka::Admin do
 
       it "create an acl and delete the newly created acl" do
         #create_acl
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
 
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
@@ -616,8 +616,8 @@ describe Rdkafka::Admin do
   end
 
   describe "#ACL tests for transactional_id" do
-    let(:transactional_id_resource_name) { TestTopics.unique(prefix: 'it-tx') }
-    let(:non_existing_transactional_id) { TestTopics.unique(prefix: 'it-non-existing-tx') }
+    let(:transactional_id_resource_name) { TestTopics.unique }
+    let(:non_existing_transactional_id) { TestTopics.unique }
     let(:transactional_id_resource_type) { Rdkafka::Bindings::RD_KAFKA_RESOURCE_TRANSACTIONAL_ID }
     let(:transactional_id_resource_pattern_type) { Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL }
     let(:transactional_id_principal) { "User:test-user" }
@@ -710,7 +710,7 @@ describe Rdkafka::Admin do
         # Create first ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: TestTopics.unique(prefix: 'it-tx'),
+          resource_name: TestTopics.unique,
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,
@@ -724,7 +724,7 @@ describe Rdkafka::Admin do
         # Create second ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: TestTopics.unique(prefix: 'it-tx'),
+          resource_name: TestTopics.unique,
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,
@@ -774,7 +774,7 @@ describe Rdkafka::Admin do
         # Create first ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: TestTopics.unique(prefix: 'it-tx'),
+          resource_name: TestTopics.unique,
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,
@@ -788,7 +788,7 @@ describe Rdkafka::Admin do
         # Create second ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: TestTopics.unique(prefix: 'it-tx'),
+          resource_name: TestTopics.unique,
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -16,14 +16,14 @@ describe Rdkafka::Admin do
     admin.close
   end
 
-  let(:topic_name)               { "test-topic-#{SecureRandom.uuid}" }
+  let(:topic_name)               { TestTopics.unique }
   let(:topic_partition_count)    { 3 }
   let(:topic_replication_factor) { 1 }
   let(:topic_config)             { {"cleanup.policy" => "compact", "min.cleanable.dirty.ratio" => 0.8} }
   let(:invalid_topic_config)     { {"cleeeeenup.policee" => "campact"} }
-  let(:group_name)               { "test-group-#{SecureRandom.uuid}" }
+  let(:group_name)               { TestTopics.unique(prefix: 'it-group') }
 
-  let(:resource_name)         {"acl-test-topic"}
+  let(:resource_name)         { TestTopics.unique(prefix: 'it-acl') }
   let(:resource_type)         {Rdkafka::Bindings::RD_KAFKA_RESOURCE_TOPIC}
   let(:resource_pattern_type) {Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL}
   let(:principal)             {"User:anonymous"}
@@ -72,7 +72,7 @@ describe Rdkafka::Admin do
       end
 
       describe "with the name of a topic that already exists" do
-        let(:topic_name) { "empty_test_topic" } # created in spec_helper.rb
+        let(:topic_name) { TestTopics.empty_test_topic } # created in spec_helper.rb
 
         it "raises an exception" do
           create_topic_handle = admin.create_topic(topic_name, topic_partition_count, topic_replication_factor)
@@ -81,7 +81,7 @@ describe Rdkafka::Admin do
           }.to raise_exception { |ex|
             expect(ex).to be_a(Rdkafka::RdkafkaError)
             expect(ex.message).to match(/Broker: Topic already exists \(topic_already_exists\)/)
-            expect(ex.broker_message).to match(/Topic 'empty_test_topic' already exists/)
+            expect(ex.broker_message).to match(/Topic '#{Regexp.escape(TestTopics.empty_test_topic)}' already exists/)
           }
         end
       end
@@ -196,7 +196,7 @@ describe Rdkafka::Admin do
     context 'when describing multiple existing topics' do
       let(:resources) do
         [
-          { resource_type: 2, resource_name: 'example_topic' },
+          { resource_type: 2, resource_name: TestTopics.example_topic },
           { resource_type: 2, resource_name: topic_name }
         ]
       end
@@ -204,7 +204,7 @@ describe Rdkafka::Admin do
       it do
         expect(resources_results.size).to eq(2)
         expect(resources_results.first.type).to eq(2)
-        expect(resources_results.first.name).to eq('example_topic')
+        expect(resources_results.first.name).to eq(TestTopics.example_topic)
         expect(resources_results.last.type).to eq(2)
         expect(resources_results.last.name).to eq(topic_name)
       end
@@ -514,7 +514,7 @@ describe Rdkafka::Admin do
   end
 
   describe "#ACL tests for topic resource" do
-    let(:non_existing_resource_name) {"non-existing-topic"}
+    let(:non_existing_resource_name) { TestTopics.unique(prefix: 'it-non-existing') }
     before do
       #create topic for testing acl
       create_topic_handle = admin.create_topic(resource_name, topic_partition_count, topic_replication_factor)
@@ -564,12 +564,12 @@ describe Rdkafka::Admin do
 
       it "create acls and describe the newly created acls" do
         #create_acl
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: "test_acl_topic_1", resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
 
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: "test_acl_topic_2", resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
@@ -595,12 +595,12 @@ describe Rdkafka::Admin do
 
       it "create an acl and delete the newly created acl" do
         #create_acl
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: "test_acl_topic_1", resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
 
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: "test_acl_topic_2", resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique(prefix: 'it-acl'), resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
@@ -616,8 +616,8 @@ describe Rdkafka::Admin do
   end
 
   describe "#ACL tests for transactional_id" do
-    let(:transactional_id_resource_name) {"test-transactional-id"}
-    let(:non_existing_transactional_id) {"non-existing-transactional-id"}
+    let(:transactional_id_resource_name) { TestTopics.unique(prefix: 'it-tx') }
+    let(:non_existing_transactional_id) { TestTopics.unique(prefix: 'it-non-existing-tx') }
     let(:transactional_id_resource_type) { Rdkafka::Bindings::RD_KAFKA_RESOURCE_TRANSACTIONAL_ID }
     let(:transactional_id_resource_pattern_type) { Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_LITERAL }
     let(:transactional_id_principal) { "User:test-user" }
@@ -710,7 +710,7 @@ describe Rdkafka::Admin do
         # Create first ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: "test_transactional_id_1",
+          resource_name: TestTopics.unique(prefix: 'it-tx'),
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,
@@ -724,7 +724,7 @@ describe Rdkafka::Admin do
         # Create second ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: "test_transactional_id_2",
+          resource_name: TestTopics.unique(prefix: 'it-tx'),
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,
@@ -774,7 +774,7 @@ describe Rdkafka::Admin do
         # Create first ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: "test_transactional_id_1",
+          resource_name: TestTopics.unique(prefix: 'it-tx'),
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,
@@ -788,7 +788,7 @@ describe Rdkafka::Admin do
         # Create second ACL
         create_acl_handle = admin.create_acl(
           resource_type: transactional_id_resource_type,
-          resource_name: "test_transactional_id_2",
+          resource_name: TestTopics.unique(prefix: 'it-tx'),
           resource_pattern_type: transactional_id_resource_pattern_type,
           principal: transactional_id_principal,
           host: transactional_id_host,

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -594,13 +594,25 @@ describe Rdkafka::Admin do
       end
 
       it "create an acl and delete the newly created acl" do
+        # Clean up any leftover ACLs from previous runs with matching filters
+        begin
+          cleanup_handle = admin.delete_acl(resource_type: resource_type, resource_name: nil, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+          cleanup_handle.wait(max_wait_timeout: 15.0)
+        rescue
+          # Ignore errors if no ACLs to clean up
+        end
+
+        # Store resource names so we can verify they were deleted
+        resource_name_1 = TestTopics.unique
+        resource_name_2 = TestTopics.unique
+
         #create_acl
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: resource_name_1, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
 
-        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: TestTopics.unique, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+        create_acl_handle = admin.create_acl(resource_type: resource_type, resource_name: resource_name_2, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
         create_acl_report = create_acl_handle.wait(max_wait_timeout: 15.0)
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")

--- a/spec/lib/rdkafka/metadata_spec.rb
+++ b/spec/lib/rdkafka/metadata_spec.rb
@@ -25,7 +25,7 @@ describe Rdkafka::Metadata do
 
     context "that is one of our test topics" do
       subject { described_class.new(native_kafka, topic_name) }
-      let(:topic_name) { "partitioner_test_topic" }
+      let(:topic_name) { TestTopics.partitioner_test_topic }
 
       it "#brokers returns our single broker" do
         expect(subject.brokers.length).to eq(1)
@@ -47,8 +47,15 @@ describe Rdkafka::Metadata do
     subject { described_class.new(native_kafka, topic_name) }
     let(:topic_name) { nil }
     let(:test_topics) {
-      %w(consume_test_topic empty_test_topic load_test_topic produce_test_topic rake_test_topic watermarks_test_topic partitioner_test_topic)
-    } # Test topics crated in spec_helper.rb
+      [
+        TestTopics.consume_test_topic,
+        TestTopics.empty_test_topic,
+        TestTopics.produce_test_topic,
+        TestTopics.watermarks_test_topic,
+        TestTopics.partitioner_test_topic,
+        TestTopics.example_topic
+      ]
+    } # Test topics created in spec_helper.rb
 
     it "#brokers returns our single broker" do
       expect(subject.brokers.length).to eq(1)

--- a/spec/lib/rdkafka/producer/delivery_handle_spec.rb
+++ b/spec/lib/rdkafka/producer/delivery_handle_spec.rb
@@ -9,7 +9,7 @@ describe Rdkafka::Producer::DeliveryHandle do
       handle[:response] = response
       handle[:partition] = 2
       handle[:offset] = 100
-      handle.topic = "produce_test_topic"
+      handle.topic = TestTopics.produce_test_topic
     end
   end
 
@@ -30,7 +30,7 @@ describe Rdkafka::Producer::DeliveryHandle do
 
         expect(report.partition).to eq(2)
         expect(report.offset).to eq(100)
-        expect(report.topic_name).to eq("produce_test_topic")
+        expect(report.topic_name).to eq(TestTopics.produce_test_topic)
       end
 
       it "should wait without a timeout" do
@@ -38,7 +38,7 @@ describe Rdkafka::Producer::DeliveryHandle do
 
         expect(report.partition).to eq(2)
         expect(report.offset).to eq(100)
-        expect(report.topic_name).to eq("produce_test_topic")
+        expect(report.topic_name).to eq(TestTopics.produce_test_topic)
       end
     end
   end

--- a/spec/lib/rdkafka/producer/delivery_report_spec.rb
+++ b/spec/lib/rdkafka/producer/delivery_report_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 describe Rdkafka::Producer::DeliveryReport do
-  subject { Rdkafka::Producer::DeliveryReport.new(2, 100, "topic", -1) }
+  let(:topic_name) { TestTopics.unique }
+  subject { Rdkafka::Producer::DeliveryReport.new(2, 100, topic_name, -1) }
 
   it "should get the partition" do
     expect(subject.partition).to eq 2
@@ -12,11 +13,11 @@ describe Rdkafka::Producer::DeliveryReport do
   end
 
   it "should get the topic_name" do
-    expect(subject.topic_name).to eq "topic"
+    expect(subject.topic_name).to eq topic_name
   end
 
   it "should get the same topic name under topic alias" do
-    expect(subject.topic).to eq "topic"
+    expect(subject.topic).to eq topic_name
   end
 
   it "should get the error" do

--- a/spec/lib/rdkafka/producer/partitions_count_cache_spec.rb
+++ b/spec/lib/rdkafka/producer/partitions_count_cache_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Rdkafka::Producer::PartitionsCountCache do
   let(:custom_ttl) { 0.5 } # Half the default TTL
   let(:cache) { described_class.new(default_ttl) }
   let(:custom_ttl_cache) { described_class.new(custom_ttl) }
-  let(:topic) { "test_topic" }
-  let(:topic2) { "test_topic2" }
+  let(:topic) { TestTopics.unique }
+  let(:topic2) { TestTopics.unique }
   let(:partition_count) { 5 }
   let(:higher_partition_count) { 10 }
   let(:lower_partition_count) { 3 }

--- a/spec/lib/rdkafka/producer_spec.rb
+++ b/spec/lib/rdkafka/producer_spec.rb
@@ -35,7 +35,7 @@ describe Rdkafka::Producer do
     context 'when config is not valid' do
       it 'expect to raise error' do
         expect do
-          producer.produce(topic: 'test', payload: '', topic_config: { 'invalid': 'invalid' })
+          producer.produce(topic: TestTopics.unique, payload: '', topic_config: { 'invalid': 'invalid' })
         end.to raise_error(Rdkafka::Config::ConfigError)
       end
     end
@@ -43,7 +43,7 @@ describe Rdkafka::Producer do
     context 'when config is valid' do
       it 'expect to raise error' do
         expect do
-          producer.produce(topic: 'test', payload: '', topic_config: { 'acks': 1 }).wait
+          producer.produce(topic: TestTopics.unique, payload: '', topic_config: { 'acks': 1 }).wait
         end.not_to raise_error
       end
 
@@ -60,7 +60,7 @@ describe Rdkafka::Producer do
         it 'expect to give up on delivery fast based on alteration config' do
           expect do
             producer.produce(
-              topic: 'produce_config_test',
+              topic: TestTopics.unique,
               payload: 'test',
               topic_config: {
                 'compression.type': 'gzip',
@@ -92,13 +92,13 @@ describe Rdkafka::Producer do
           expect(report.label).to eq "label"
           expect(report.partition).to eq 1
           expect(report.offset).to be >= 0
-          expect(report.topic_name).to eq "produce_test_topic"
+          expect(report.topic_name).to eq TestTopics.produce_test_topic
           @callback_called = true
         end
 
         # Produce a message
         handle = producer.produce(
-          topic:   "produce_test_topic",
+          topic:   TestTopics.produce_test_topic,
           payload: "payload",
           key:     "key",
           label:   "label"
@@ -123,7 +123,7 @@ describe Rdkafka::Producer do
 
         # Produce a message
         handle = producer.produce(
-          topic:   "produce_test_topic",
+          topic:   TestTopics.produce_test_topic,
           payload: "payload",
           key:     "key"
         )
@@ -164,7 +164,7 @@ describe Rdkafka::Producer do
 
         # Produce a message
         handle = producer.produce(
-          topic:   "produce_test_topic",
+          topic:   TestTopics.produce_test_topic,
           payload: "payload",
           key:     "key"
         )
@@ -179,7 +179,7 @@ describe Rdkafka::Producer do
         expect(called_report.first).not_to be_nil
         expect(called_report.first.partition).to eq 1
         expect(called_report.first.offset).to be >= 0
-        expect(called_report.first.topic_name).to eq "produce_test_topic"
+        expect(called_report.first.topic_name).to eq TestTopics.produce_test_topic
       end
 
       it "should provide handle" do
@@ -197,7 +197,7 @@ describe Rdkafka::Producer do
 
         # Produce a message
         handle = producer.produce(
-          topic:   "produce_test_topic",
+          topic:   TestTopics.produce_test_topic,
           payload: "payload",
           key:     "key"
         )
@@ -232,7 +232,7 @@ describe Rdkafka::Producer do
   it "should produce a message" do
     # Produce a message
     handle = producer.produce(
-      topic:   "produce_test_topic",
+      topic:   TestTopics.produce_test_topic,
       payload: "payload",
       key:     "key",
       label:   "label"
@@ -256,7 +256,7 @@ describe Rdkafka::Producer do
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -269,7 +269,7 @@ describe Rdkafka::Producer do
   it "should produce a message with a specified partition" do
     # Produce a message
     handle = producer.produce(
-      topic:     "produce_test_topic",
+      topic:     TestTopics.produce_test_topic,
       payload:   "payload partition",
       key:       "key partition",
       partition: 1
@@ -278,7 +278,7 @@ describe Rdkafka::Producer do
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -291,7 +291,7 @@ describe Rdkafka::Producer do
     while true
       key = ('a'..'z').to_a.shuffle.take(10).join('')
       partition_key = ('a'..'z').to_a.shuffle.take(10).join('')
-      partition_count = producer.partition_count('partitioner_test_topic')
+      partition_count = producer.partition_count(TestTopics.partitioner_test_topic)
       break if (Zlib.crc32(key) % partition_count) != (Zlib.crc32(partition_key) % partition_count)
     end
 
@@ -300,7 +300,7 @@ describe Rdkafka::Producer do
 
     messages = messages.map do |m|
       handle = producer.produce(
-        topic:     "partitioner_test_topic",
+        topic:     TestTopics.partitioner_test_topic,
         payload:   "payload partition",
         key:       m[:key],
         partition_key: m[:partition_key]
@@ -308,7 +308,7 @@ describe Rdkafka::Producer do
       report = handle.wait(max_wait_timeout: 5)
 
       wait_for_message(
-        topic: "partitioner_test_topic",
+        topic: TestTopics.partitioner_test_topic,
         delivery_report: report,
       )
     end
@@ -325,7 +325,7 @@ describe Rdkafka::Producer do
 
     messages = messages.map do |m|
       handle = producer.produce(
-        topic:     "partitioner_test_topic",
+        topic:     TestTopics.partitioner_test_topic,
         payload:   "payload partition",
         key:       m[:key],
         partition_key: m[:partition_key]
@@ -333,7 +333,7 @@ describe Rdkafka::Producer do
       report = handle.wait(max_wait_timeout: 5)
 
       wait_for_message(
-        topic: "partitioner_test_topic",
+        topic: TestTopics.partitioner_test_topic,
         delivery_report: report,
       )
     end
@@ -344,7 +344,7 @@ describe Rdkafka::Producer do
 
   it "should produce a message with utf-8 encoding" do
     handle = producer.produce(
-      topic:   "produce_test_topic",
+      topic:   TestTopics.produce_test_topic,
       payload: "Τη γλώσσα μου έδωσαν ελληνική",
       key:     "key utf8"
     )
@@ -352,7 +352,7 @@ describe Rdkafka::Producer do
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -363,7 +363,7 @@ describe Rdkafka::Producer do
   end
 
   it "should produce a message to a non-existing topic with key and partition key" do
-    new_topic = "it-#{SecureRandom.uuid}"
+    new_topic = TestTopics.unique
 
     handle = producer.produce(
       # Needs to be a new topic each time
@@ -406,7 +406,7 @@ describe Rdkafka::Producer do
     it "should raise a type error if not nil, integer or time" do
       expect {
         producer.produce(
-          topic:     "produce_test_topic",
+          topic:     TestTopics.produce_test_topic,
           payload:   "payload timestamp",
           key:       "key timestamp",
           timestamp: "10101010"
@@ -416,7 +416,7 @@ describe Rdkafka::Producer do
 
     it "should produce a message with an integer timestamp" do
       handle = producer.produce(
-        topic:     "produce_test_topic",
+        topic:     TestTopics.produce_test_topic,
         payload:   "payload timestamp",
         key:       "key timestamp",
         timestamp: 1505069646252
@@ -425,7 +425,7 @@ describe Rdkafka::Producer do
 
       # Consume message and verify its content
       message = wait_for_message(
-        topic: "produce_test_topic",
+        topic: TestTopics.produce_test_topic,
         delivery_report: report,
         consumer: consumer
       )
@@ -437,7 +437,7 @@ describe Rdkafka::Producer do
 
     it "should produce a message with a time timestamp" do
       handle = producer.produce(
-        topic:     "produce_test_topic",
+        topic:     TestTopics.produce_test_topic,
         payload:   "payload timestamp",
         key:       "key timestamp",
         timestamp: Time.at(1505069646, 353_000)
@@ -446,7 +446,7 @@ describe Rdkafka::Producer do
 
       # Consume message and verify its content
       message = wait_for_message(
-        topic: "produce_test_topic",
+        topic: TestTopics.produce_test_topic,
         delivery_report: report,
         consumer: consumer
       )
@@ -459,14 +459,14 @@ describe Rdkafka::Producer do
 
   it "should produce a message with nil key" do
     handle = producer.produce(
-      topic:   "produce_test_topic",
+      topic:   TestTopics.produce_test_topic,
       payload: "payload no key"
     )
     report = handle.wait(max_wait_timeout: 5)
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -477,14 +477,14 @@ describe Rdkafka::Producer do
 
   it "should produce a message with nil payload" do
     handle = producer.produce(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       key:   "key no payload"
     )
     report = handle.wait(max_wait_timeout: 5)
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -495,7 +495,7 @@ describe Rdkafka::Producer do
 
   it "should produce a message with headers" do
     handle = producer.produce(
-      topic:     "produce_test_topic",
+      topic:     TestTopics.produce_test_topic,
       payload:   "payload headers",
       key:       "key headers",
       headers:   { foo: :bar, baz: :foobar }
@@ -504,7 +504,7 @@ describe Rdkafka::Producer do
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -518,7 +518,7 @@ describe Rdkafka::Producer do
 
   it "should produce a message with empty headers" do
     handle = producer.produce(
-      topic:     "produce_test_topic",
+      topic:     TestTopics.produce_test_topic,
       payload:   "payload headers",
       key:       "key headers",
       headers:   {}
@@ -527,7 +527,7 @@ describe Rdkafka::Producer do
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -541,7 +541,7 @@ describe Rdkafka::Producer do
     5.times do
       200.times do
         producer.produce(
-          topic:   "produce_test_topic",
+          topic:   TestTopics.produce_test_topic,
           payload: "payload not waiting",
           key:     "key not waiting"
         )
@@ -570,7 +570,7 @@ describe Rdkafka::Producer do
       producer = rdkafka_producer_config.producer
 
       handle = producer.produce(
-        topic:   "produce_test_topic",
+        topic:   TestTopics.produce_test_topic,
         payload: "payload-forked",
         key:     "key-forked"
       )
@@ -602,7 +602,7 @@ describe Rdkafka::Producer do
 
     # Consume message and verify its content
     message = wait_for_message(
-      topic: "produce_test_topic",
+      topic: TestTopics.produce_test_topic,
       delivery_report: report,
       consumer: consumer
     )
@@ -616,7 +616,7 @@ describe Rdkafka::Producer do
 
     expect {
       producer.produce(
-        topic:   "produce_test_topic",
+        topic:   TestTopics.produce_test_topic,
         key:     "key error"
       )
     }.to raise_error Rdkafka::RdkafkaError
@@ -624,7 +624,7 @@ describe Rdkafka::Producer do
 
   it "should raise a timeout error when waiting too long" do
     handle = producer.produce(
-      topic:   "produce_test_topic",
+      topic:   TestTopics.produce_test_topic,
       payload: "payload timeout",
       key:     "key timeout"
     )
@@ -667,7 +667,7 @@ describe Rdkafka::Producer do
     end
 
     it "should contain the error in the response when not deliverable" do
-      handler = producer.produce(topic: 'produce_test_topic', payload: nil, label: 'na')
+      handler = producer.produce(topic: TestTopics.produce_test_topic, payload: nil, label: 'na')
       # Wait for the async callbacks and delivery registry to update
       sleep(2)
       expect(handler.create_result.error).to be_a(Rdkafka::RdkafkaError)
@@ -685,7 +685,7 @@ describe Rdkafka::Producer do
     end
 
     it "should contain the error in the response when not deliverable" do
-      handler = producer.produce(topic: "it-#{SecureRandom.uuid}", payload: nil, label: 'na')
+      handler = producer.produce(topic: TestTopics.unique, payload: nil, label: 'na')
       # Wait for the async callbacks and delivery registry to update
       sleep(2)
       expect(handler.create_result.error).to be_a(Rdkafka::RdkafkaError)
@@ -695,16 +695,16 @@ describe Rdkafka::Producer do
   end
 
   describe '#partition_count' do
-    it { expect(producer.partition_count('example_topic')).to eq(1) }
+    it { expect(producer.partition_count(TestTopics.example_topic)).to eq(1) }
 
     context 'when the partition count value is already cached' do
       before do
-        producer.partition_count('example_topic')
+        producer.partition_count(TestTopics.example_topic)
         allow(::Rdkafka::Metadata).to receive(:new).and_call_original
       end
 
       it 'expect not to query it again' do
-        producer.partition_count('example_topic')
+        producer.partition_count(TestTopics.example_topic)
         expect(::Rdkafka::Metadata).not_to have_received(:new)
       end
     end
@@ -716,7 +716,7 @@ describe Rdkafka::Producer do
       end
 
       it 'expect to query it again' do
-        producer.partition_count('example_topic')
+        producer.partition_count(TestTopics.example_topic)
         expect(::Rdkafka::Metadata).to have_received(:new)
       end
     end
@@ -724,19 +724,19 @@ describe Rdkafka::Producer do
     context 'when the partition count value was cached and time did not expire' do
       before do
         allow(::Process).to receive(:clock_gettime).and_return(0, 29.001)
-        producer.partition_count('example_topic')
+        producer.partition_count(TestTopics.example_topic)
         allow(::Rdkafka::Metadata).to receive(:new).and_call_original
       end
 
       it 'expect not to query it again' do
-        producer.partition_count('example_topic')
+        producer.partition_count(TestTopics.example_topic)
         expect(::Rdkafka::Metadata).not_to have_received(:new)
       end
     end
   end
 
   describe 'metadata fetch request recovery' do
-    subject(:partition_count) { producer.partition_count('example_topic') }
+    subject(:partition_count) { producer.partition_count(TestTopics.example_topic) }
 
     describe 'metadata initialization recovery' do
       context 'when all good' do
@@ -765,7 +765,7 @@ describe Rdkafka::Producer do
   describe '#flush' do
     it "should return flush when it can flush all outstanding messages or when no messages" do
       producer.produce(
-        topic:     "produce_test_topic",
+        topic:     TestTopics.produce_test_topic,
         payload:   "payload headers",
         key:       "key headers",
         headers:   {}
@@ -790,7 +790,7 @@ describe Rdkafka::Producer do
 
       it "should return false on flush when cannot deliver and beyond timeout" do
         producer.produce(
-          topic:     "produce_test_topic",
+          topic:     TestTopics.produce_test_topic,
           payload:   "payload headers",
           key:       "key headers",
           headers:   {}
@@ -832,7 +832,7 @@ describe Rdkafka::Producer do
 
       it "should should purge and move forward" do
         producer.produce(
-          topic:     "produce_test_topic",
+          topic:     TestTopics.produce_test_topic,
           payload:   "payload headers"
         )
 
@@ -842,7 +842,7 @@ describe Rdkafka::Producer do
 
       it "should materialize the delivery handles" do
         handle = producer.produce(
-          topic:     "produce_test_topic",
+          topic:     TestTopics.produce_test_topic,
           payload:   "payload headers"
         )
 
@@ -862,7 +862,7 @@ describe Rdkafka::Producer do
 
         it "should run the callback" do
           producer.produce(
-            topic:     "produce_test_topic",
+            topic:     TestTopics.produce_test_topic,
             payload:   "payload headers"
           )
 
@@ -884,7 +884,7 @@ describe Rdkafka::Producer do
 
     it 'expect not to allow to produce without transaction init' do
       expect do
-        producer.produce(topic: 'produce_test_topic', payload: 'data')
+        producer.produce(topic: TestTopics.produce_test_topic, payload: 'data')
       end.to raise_error(Rdkafka::RdkafkaError, /Erroneous state \(state\)/)
     end
 
@@ -892,22 +892,22 @@ describe Rdkafka::Producer do
       producer.init_transactions
 
       expect do
-        producer.produce(topic: 'produce_test_topic', payload: 'data')
+        producer.produce(topic: TestTopics.produce_test_topic, payload: 'data')
       end.to raise_error(Rdkafka::RdkafkaError, /Erroneous state \(state\)/)
     end
 
     it 'expect to allow to produce within a transaction, finalize and ship data' do
       producer.init_transactions
       producer.begin_transaction
-      handle1 = producer.produce(topic: 'produce_test_topic', payload: 'data1', partition: 1)
-      handle2 = producer.produce(topic: 'example_topic', payload: 'data2', partition: 0)
+      handle1 = producer.produce(topic: TestTopics.produce_test_topic, payload: 'data1', partition: 1)
+      handle2 = producer.produce(topic: TestTopics.example_topic, payload: 'data2', partition: 0)
       producer.commit_transaction
 
       report1 = handle1.wait(max_wait_timeout: 15)
       report2 = handle2.wait(max_wait_timeout: 15)
 
       message1 = wait_for_message(
-        topic: "produce_test_topic",
+        topic: TestTopics.produce_test_topic,
         delivery_report: report1,
         consumer: consumer
       )
@@ -917,7 +917,7 @@ describe Rdkafka::Producer do
       expect(message1.timestamp).to be_within(10).of(Time.now)
 
       message2 = wait_for_message(
-        topic: "example_topic",
+        topic: TestTopics.example_topic,
         delivery_report: report2,
         consumer: consumer
       )
@@ -930,8 +930,8 @@ describe Rdkafka::Producer do
     it 'expect not to send data and propagate purge queue error on abort' do
       producer.init_transactions
       producer.begin_transaction
-      handle1 = producer.produce(topic: 'produce_test_topic', payload: 'data1', partition: 1)
-      handle2 = producer.produce(topic: 'example_topic', payload: 'data2', partition: 0)
+      handle1 = producer.produce(topic: TestTopics.produce_test_topic, payload: 'data1', partition: 1)
+      handle2 = producer.produce(topic: TestTopics.example_topic, payload: 'data2', partition: 0)
       producer.abort_transaction
 
       expect { handle1.wait(max_wait_timeout: 15) }
@@ -943,7 +943,7 @@ describe Rdkafka::Producer do
     it 'expect to have non retryable, non abortable and not fatal error on abort' do
       producer.init_transactions
       producer.begin_transaction
-      handle = producer.produce(topic: 'produce_test_topic', payload: 'data1', partition: 1)
+      handle = producer.produce(topic: TestTopics.produce_test_topic, payload: 'data1', partition: 1)
       producer.abort_transaction
 
       response = handle.wait(raise_response_error: false)
@@ -979,11 +979,11 @@ describe Rdkafka::Producer do
       it 'expect older producer not to be able to commit when fanced out' do
         producer1.init_transactions
         producer1.begin_transaction
-        producer1.produce(topic: 'produce_test_topic', payload: 'data1', partition: 1)
+        producer1.produce(topic: TestTopics.produce_test_topic, payload: 'data1', partition: 1)
 
         producer2.init_transactions
         producer2.begin_transaction
-        producer2.produce(topic: 'produce_test_topic', payload: 'data1', partition: 1)
+        producer2.produce(topic: TestTopics.produce_test_topic, payload: 'data1', partition: 1)
 
         expect { producer1.commit_transaction }
           .to raise_error(Rdkafka::RdkafkaError, /This instance has been fenced/)
@@ -1006,16 +1006,16 @@ describe Rdkafka::Producer do
 
     context 'when having a consumer with tpls for exactly once semantics' do
       let(:tpl) do
-        producer.produce(topic: 'consume_test_topic', payload: 'data1', partition: 0).wait
-        result = producer.produce(topic: 'consume_test_topic', payload: 'data1', partition: 0).wait
+        producer.produce(topic: TestTopics.consume_test_topic, payload: 'data1', partition: 0).wait
+        result = producer.produce(topic: TestTopics.consume_test_topic, payload: 'data1', partition: 0).wait
 
         Rdkafka::Consumer::TopicPartitionList.new.tap do |list|
-          list.add_topic_and_partitions_with_offsets("consume_test_topic", 0 => result.offset + 1)
+          list.add_topic_and_partitions_with_offsets(TestTopics.consume_test_topic, 0 => result.offset + 1)
         end
       end
 
       before do
-        consumer.subscribe("consume_test_topic")
+        consumer.subscribe(TestTopics.consume_test_topic)
         wait_for_assignment(consumer)
         producer.init_transactions
         producer.begin_transaction
@@ -1068,12 +1068,12 @@ describe Rdkafka::Producer do
       }
 
       report = producer.produce(
-        topic:     "consume_test_topic",
+        topic:     TestTopics.consume_test_topic,
         key:       "key headers",
         headers:   headers
       ).wait
 
-      message = wait_for_message(topic: "consume_test_topic", consumer: consumer, delivery_report: report)
+      message = wait_for_message(topic: TestTopics.consume_test_topic, consumer: consumer, delivery_report: report)
       expect(message).to be
       expect(message.key).to eq('key headers')
       expect(message.headers['type']).to eq('String')
@@ -1087,12 +1087,12 @@ describe Rdkafka::Producer do
       }
 
       report = producer.produce(
-        topic:     "consume_test_topic",
+        topic:     TestTopics.consume_test_topic,
         key:       "key headers",
         headers:   headers
       ).wait
 
-      message = wait_for_message(topic: "consume_test_topic", consumer: consumer, delivery_report: report)
+      message = wait_for_message(topic: TestTopics.consume_test_topic, consumer: consumer, delivery_report: report)
       expect(message).to be
       expect(message.key).to eq('key headers')
       expect(message.headers['type']).to eq('String')
@@ -1106,8 +1106,8 @@ describe Rdkafka::Producer do
     end
 
     let(:count_cache_hash) { described_class.partitions_count_cache.to_h }
-    let(:pre_statistics_ttl) { count_cache_hash.fetch('produce_test_topic', [])[0] }
-    let(:post_statistics_ttl) { count_cache_hash.fetch('produce_test_topic', [])[0] }
+    let(:pre_statistics_ttl) { count_cache_hash.fetch(TestTopics.produce_test_topic, [])[0] }
+    let(:post_statistics_ttl) { count_cache_hash.fetch(TestTopics.produce_test_topic, [])[0] }
 
     context "when using partition key" do
       before do
@@ -1115,7 +1115,7 @@ describe Rdkafka::Producer do
 
         # This call will make a blocking request to the metadata cache
         producer.produce(
-          topic:         "produce_test_topic",
+          topic:         TestTopics.produce_test_topic,
           payload:       "payload headers",
           partition_key: "test"
         ).wait
@@ -1139,7 +1139,7 @@ describe Rdkafka::Producer do
 
         # This call will make a blocking request to the metadata cache
         producer.produce(
-          topic:         "produce_test_topic",
+          topic:         TestTopics.produce_test_topic,
           payload:       "payload headers"
         ).wait
 
@@ -1165,14 +1165,14 @@ describe Rdkafka::Producer do
     end
 
     let(:count_cache_hash) { described_class.partitions_count_cache.to_h }
-    let(:pre_statistics_ttl) { count_cache_hash.fetch('produce_test_topic', [])[0] }
-    let(:post_statistics_ttl) { count_cache_hash.fetch('produce_test_topic', [])[0] }
+    let(:pre_statistics_ttl) { count_cache_hash.fetch(TestTopics.produce_test_topic, [])[0] }
+    let(:post_statistics_ttl) { count_cache_hash.fetch(TestTopics.produce_test_topic, [])[0] }
 
     context "when using partition key" do
       before do
         # This call will make a blocking request to the metadata cache
         producer.produce(
-          topic:         "produce_test_topic",
+          topic:         TestTopics.produce_test_topic,
           payload:       "payload headers",
           partition_key: "test"
         ).wait
@@ -1194,7 +1194,7 @@ describe Rdkafka::Producer do
       before do
         # This call will make a blocking request to the metadata cache
         producer.produce(
-          topic:         "produce_test_topic",
+          topic:         TestTopics.produce_test_topic,
           payload:       "payload headers"
         ).wait
 
@@ -1240,7 +1240,7 @@ describe Rdkafka::Producer do
 
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             partition_key: test_key,
             partitioner: partitioner
@@ -1260,7 +1260,7 @@ describe Rdkafka::Producer do
       it "should produce message with empty partition key without crashing and go to partition 0 for all partitioners" do
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             key: "test-key",
             partition_key: "",
@@ -1276,7 +1276,7 @@ describe Rdkafka::Producer do
     context "nil partition key" do
       it "should handle nil partition key gracefully" do
         handle = producer.produce(
-          topic: "partitioner_test_topic",
+          topic: TestTopics.partitioner_test_topic,
           payload: "test payload",
           key: "test-key",
           partition_key: nil
@@ -1284,7 +1284,7 @@ describe Rdkafka::Producer do
 
         report = handle.wait(max_wait_timeout: 5)
         expect(report.partition).to be >= 0
-        expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+        expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
       end
     end
 
@@ -1292,7 +1292,7 @@ describe Rdkafka::Producer do
       it "should handle very short keys with all partitioners" do
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             partition_key: "a",
             partitioner: partitioner
@@ -1300,7 +1300,7 @@ describe Rdkafka::Producer do
 
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
-          expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+          expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
         end
       end
 
@@ -1309,7 +1309,7 @@ describe Rdkafka::Producer do
 
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             partition_key: long_key,
             partitioner: partitioner
@@ -1317,7 +1317,7 @@ describe Rdkafka::Producer do
 
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
-          expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+          expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
         end
       end
 
@@ -1326,7 +1326,7 @@ describe Rdkafka::Producer do
 
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             partition_key: unicode_key,
             partitioner: partitioner
@@ -1334,7 +1334,7 @@ describe Rdkafka::Producer do
 
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
-          expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+          expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
         end
       end
     end
@@ -1347,7 +1347,7 @@ describe Rdkafka::Producer do
           # Produce multiple messages with same partition key
           reports = 5.times.map do
             handle = producer.produce(
-              topic: "partitioner_test_topic",
+              topic: TestTopics.partitioner_test_topic,
               payload: "test payload #{Time.now.to_f}",
               partition_key: partition_key,
               partitioner: partitioner
@@ -1370,7 +1370,7 @@ describe Rdkafka::Producer do
 
           reports = 10.times.map do
             handle = producer.produce(
-              topic: "partitioner_test_topic",
+              topic: TestTopics.partitioner_test_topic,
               payload: "test payload #{Time.now.to_f}",
               partition_key: partition_key,
               partitioner: partitioner
@@ -1383,7 +1383,7 @@ describe Rdkafka::Producer do
           # Just ensure they're valid partitions
           partitions.each do |partition|
             expect(partition).to be >= 0
-            expect(partition).to be < producer.partition_count("partitioner_test_topic")
+            expect(partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
           end
         end
       end
@@ -1396,7 +1396,7 @@ describe Rdkafka::Producer do
         all_partitioners.each do |partitioner|
           reports = keys.map do |key|
             handle = producer.produce(
-              topic: "partitioner_test_topic",
+              topic: TestTopics.partitioner_test_topic,
               payload: "test payload",
               partition_key: key,
               partitioner: partitioner
@@ -1408,7 +1408,7 @@ describe Rdkafka::Producer do
 
           # Should distribute across multiple partitions for most partitioners
           # (though some might hash all keys to same partition by chance)
-          expect(partitions.all? { |p| p >= 0 && p < producer.partition_count("partitioner_test_topic") }).to be true
+          expect(partitions.all? { |p| p >= 0 && p < producer.partition_count(TestTopics.partitioner_test_topic) }).to be true
         end
       end
     end
@@ -1421,7 +1421,7 @@ describe Rdkafka::Producer do
 
         # Message with both keys
         handle1 = producer.produce(
-          topic: "partitioner_test_topic",
+          topic: TestTopics.partitioner_test_topic,
           payload: "test payload 1",
           key: regular_key,
           partition_key: partition_key
@@ -1429,14 +1429,14 @@ describe Rdkafka::Producer do
 
         # Message with only partition key (should go to same partition)
         handle2 = producer.produce(
-          topic: "partitioner_test_topic",
+          topic: TestTopics.partitioner_test_topic,
           payload: "test payload 2",
           partition_key: partition_key
         )
 
         # Message with only regular key (should go to different partition)
         handle3 = producer.produce(
-          topic: "partitioner_test_topic",
+          topic: TestTopics.partitioner_test_topic,
           payload: "test payload 3",
           key: regular_key
         )
@@ -1457,7 +1457,7 @@ describe Rdkafka::Producer do
       it "should handle nil partition key with all partitioners" do
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             key: "test-key",
             partition_key: nil,
@@ -1466,14 +1466,14 @@ describe Rdkafka::Producer do
 
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
-          expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+          expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
         end
       end
 
       it "should handle whitespace-only partition key with all partitioners" do
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             partition_key: "   ",
             partitioner: partitioner
@@ -1481,14 +1481,14 @@ describe Rdkafka::Producer do
 
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
-          expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+          expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
         end
       end
 
       it "should handle newline characters in partition key with all partitioners" do
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "test payload",
             partition_key: "key\nwith\nnewlines",
             partitioner: partitioner
@@ -1496,7 +1496,7 @@ describe Rdkafka::Producer do
 
           report = handle.wait(max_wait_timeout: 5)
           expect(report.partition).to be >= 0
-          expect(report.partition).to be < producer.partition_count("partitioner_test_topic")
+          expect(report.partition).to be < producer.partition_count(TestTopics.partitioner_test_topic)
         end
       end
     end
@@ -1508,7 +1508,7 @@ describe Rdkafka::Producer do
 
         all_partitioners.each do |partitioner|
           handle = producer.produce(
-            topic: "partitioner_test_topic",
+            topic: TestTopics.partitioner_test_topic,
             payload: "debug payload",
             partition_key: test_key,
             partitioner: partitioner


### PR DESCRIPTION
This PR normalizes specs topics so they align with the karafka `it-` (from internal testing) format and makes sure we have topics per suite.