### PR TITLE
Add statistics.unassigned.include librdkafka config property

### DIFF
--- a/.github/workflows/ci_linux_alpine_aarch64_musl_complementary.yml
+++ b/.github/workflows/ci_linux_alpine_aarch64_musl_complementary.yml
@@ -19,7 +19,7 @@
 # - Tests real SSL scenarios that mirror Alpine ARM64-based production deployments
 #
 # INTEGRATION TESTING (integration specs in both jobs):
-# - Tests musl libc and Alpine system library compatibility on ARM64 without requiring Kafka infrastructure
+# - Tests musl libc and Alpine system library compatibility on ARM64 including Kafka connectivity
 # - Validates libssl, libsasl2, libzstd, zlib integration across Alpine versions on ARM64
 # - Ensures native extensions work with different Alpine package versions on ARM64
 # - Catches regressions from Alpine package updates and musl libc changes on ARM64
@@ -167,6 +167,7 @@ jobs:
       - name: Run integration specs (compiled flow)
         run: |
           docker run --rm --platform linux/arm64 \
+            --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ruby:${{ matrix.ruby }}-alpine${{ matrix.alpine_version }} \
@@ -259,6 +260,7 @@ jobs:
           RDKAFKA_PRECOMPILED: "true"
         run: |
           docker run --rm --platform linux/arm64 \
+            --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \

--- a/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
+++ b/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
@@ -20,7 +20,7 @@
 # - Tests real SSL scenarios that mirror Alpine-based production deployments
 #
 # INTEGRATION TESTING (integration specs in both jobs):
-# - Tests musl libc and Alpine system library compatibility without requiring Kafka infrastructure
+# - Tests musl libc and Alpine system library compatibility including Kafka connectivity
 # - Validates libssl, libsasl2, libzstd, zlib integration across Alpine versions
 # - Ensures native extensions work with different Alpine package versions
 # - Catches regressions from Alpine package updates and musl libc changes
@@ -164,6 +164,7 @@ jobs:
       - name: Run integration specs (compiled flow)
         run: |
           docker run --rm \
+            --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ruby:${{ matrix.ruby }}-alpine${{ matrix.alpine_version }} \
@@ -251,6 +252,7 @@ jobs:
           RDKAFKA_PRECOMPILED: "true"
         run: |
           docker run --rm \
+            --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \

--- a/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
@@ -26,7 +26,7 @@
 # - Tests real SSL scenarios that mirror production deployments
 #
 # INTEGRATION TESTING (integration specs in both jobs):
-# - Tests system library compatibility without requiring Kafka infrastructure
+# - Tests system library compatibility including Kafka connectivity
 # - Validates libssl, libsasl2, libzstd, zlib integration across OS versions
 # - Ensures native extensions work with different system library versions
 # - Catches regressions from Debian package updates and system changes
@@ -225,6 +225,7 @@ jobs:
       - name: Run integration specs (compiled flow)
         run: |
           docker run --rm \
+            --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             ruby:${{ matrix.ruby }}-${{ matrix.debian }} \
@@ -316,6 +317,7 @@ jobs:
           RDKAFKA_PRECOMPILED: "true"
         run: |
           docker run --rm \
+            --network host \
             -v "${{ github.workspace }}:/workspace" \
             -w /workspace \
             -e "RDKAFKA_EXT_PATH=/workspace/ext" \

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -132,6 +132,10 @@ RSpec/OverwritingSetup:
 RSpec/RepeatedDescription:
   Enabled: false
 
+RSpec/Output:
+  Exclude:
+    - spec/integrations/**/*
+
 RSpec/SpecFilePathFormat:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.25.1 (2026-04-08)
+- **[Feature]** Add `statistics.unassigned.include` librdkafka config property (default: `true`) to filter unassigned partition data from statistics JSON. When set to `false`, producers emit an empty topics section and consumers exclude partitions whose fetch state has not started. Partition counters still contribute to root-level aggregate totals. Reduces statistics JSON size significantly on large clusters.
+
 ## 0.25.0 (2026-04-02)
 - **[Feature]** Support `rd_kafka_ListOffsets` admin API for querying partition offsets by specification (earliest, latest, max_timestamp, or by timestamp) without requiring a consumer group (from upstream).
 - **[Feature]** Extend `Rdkafka::RdkafkaError` with `instance_name` attribute containing the `rd_kafka_name` for tying errors back to specific native Kafka instances (from upstream).

--- a/dist/patches/rdkafka_stats_filter.patch
+++ b/dist/patches/rdkafka_stats_filter.patch
@@ -1,5 +1,5 @@
 --- librdkafka-2.13.2.orig/src/rdkafka.c	2026-04-08 13:20:01.569341019 +0200
-+++ librdkafka-2.13.2/src/rdkafka.c	2026-04-08 13:20:57.667328799 +0200
++++ librdkafka-2.13.2/src/rdkafka.c	2026-04-08 15:56:38.885500626 +0200
 @@ -1476,6 +1476,29 @@
  }
  
@@ -137,8 +137,8 @@
 +                        first_partition = 1;
 +                        for (i = 0; i < rkt->rkt_partition_cnt; i++) {
 +                                if (filter_unassigned &&
-+                                    !RD_KAFKA_TOPPAR_FETCH_IS_STARTED(
-+                                        rkt->rkt_p[i]->rktp_fetch_state)) {
++                                    rkt->rkt_p[i]->rktp_fetch_state ==
++                                        RD_KAFKA_TOPPAR_FETCH_NONE) {
 +                                        rd_kafka_stats_accum_toppar(
 +                                            &total, rkt->rkt_p[i]);
 +                                        continue;

--- a/dist/patches/rdkafka_stats_filter.patch
+++ b/dist/patches/rdkafka_stats_filter.patch
@@ -1,5 +1,5 @@
---- librdkafka-2.13.2.orig/src/rdkafka.c	2026-04-08 13:20:01.569341019 +0200
-+++ librdkafka-2.13.2/src/rdkafka.c	2026-04-08 15:56:38.885500626 +0200
+--- librdkafka-2.13.2.orig/src/rdkafka.c	2026-02-26 08:38:12.000000000 +0100
++++ librdkafka-2.13.2/src/rdkafka.c	2026-04-09 10:51:54.945305426 +0200
 @@ -1476,6 +1476,29 @@
  }
  
@@ -30,7 +30,70 @@
   * Emit stats for toppar
   */
  static RD_INLINE void rd_kafka_stats_emit_toppar(struct _stats_emit *st,
-@@ -1922,52 +1945,96 @@
+@@ -1901,18 +1924,51 @@
+ 
+                 _st_printf("\"toppars\":{ " /*open toppars*/);
+ 
+-                TAILQ_FOREACH(rktp, &rkb->rkb_toppars, rktp_rkblink) {
+-                        _st_printf(
+-                            "%s\"%.*s-%" PRId32
+-                            "\": { "
+-                            "\"topic\":\"%.*s\", "
+-                            "\"partition\":%" PRId32 "} ",
+-                            rktp == TAILQ_FIRST(&rkb->rkb_toppars) ? "" : ", ",
+-                            RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+-                            rktp->rktp_partition,
+-                            RD_KAFKAP_STR_PR(rktp->rktp_rkt->rkt_topic),
+-                            rktp->rktp_partition);
++                if (rk->rk_conf.stats_include_unassigned) {
++                        TAILQ_FOREACH(rktp, &rkb->rkb_toppars,
++                                      rktp_rkblink) {
++                                _st_printf(
++                                    "%s\"%.*s-%" PRId32
++                                    "\": { "
++                                    "\"topic\":\"%.*s\", "
++                                    "\"partition\":%" PRId32 "} ",
++                                    rktp == TAILQ_FIRST(&rkb->rkb_toppars)
++                                        ? ""
++                                        : ", ",
++                                    RD_KAFKAP_STR_PR(
++                                        rktp->rktp_rkt->rkt_topic),
++                                    rktp->rktp_partition,
++                                    RD_KAFKAP_STR_PR(
++                                        rktp->rktp_rkt->rkt_topic),
++                                    rktp->rktp_partition);
++                        }
++                } else if (rk->rk_type == RD_KAFKA_CONSUMER) {
++                        /* Consumer with filter: emit only actively fetching
++                         * partitions. Skip unassigned partitions (fetch
++                         * state NONE) to reduce statistics output size. */
++                        int first_toppar = 1;
++                        TAILQ_FOREACH(rktp, &rkb->rkb_toppars,
++                                      rktp_rkblink) {
++                                if (rktp->rktp_fetch_state ==
++                                    RD_KAFKA_TOPPAR_FETCH_NONE)
++                                        continue;
++                                _st_printf(
++                                    "%s\"%.*s-%" PRId32
++                                    "\": { "
++                                    "\"topic\":\"%.*s\", "
++                                    "\"partition\":%" PRId32 "} ",
++                                    first_toppar ? "" : ", ",
++                                    RD_KAFKAP_STR_PR(
++                                        rktp->rktp_rkt->rkt_topic),
++                                    rktp->rktp_partition,
++                                    RD_KAFKAP_STR_PR(
++                                        rktp->rktp_rkt->rkt_topic),
++                                    rktp->rktp_partition);
++                                first_toppar = 0;
++                        }
+                 }
++                /* Producer with filter: emit empty toppars section since
++                 * producers don't have the assigned/unassigned concept. */
+ 
+                 rd_kafka_broker_unlock(rkb);
+ 
+@@ -1922,52 +1978,96 @@
          }
  
  
@@ -85,15 +148,15 @@
 -                        rd_kafka_stats_emit_toppar(st, NULL, rkt->rkt_ua,
 -                                                   i++ == 0);
 +                        rd_kafka_topic_rdlock(rkt);
- 
--                rd_kafka_topic_rdunlock(rkt);
++
 +                        for (i = 0; i < rkt->rkt_partition_cnt; i++)
 +                                rd_kafka_stats_accum_toppar(&total,
 +                                                            rkt->rkt_p[i]);
 +
 +                        RD_LIST_FOREACH(rktp, &rkt->rkt_desp, j)
 +                        rd_kafka_stats_accum_toppar(&total, rktp);
-+
+ 
+-                rd_kafka_topic_rdunlock(rkt);
 +                        rd_kafka_topic_rdunlock(rkt);
 +                }
 +        } else {
@@ -168,8 +231,8 @@
          }
          _st_printf("} " /*close topics*/);
  
---- librdkafka-2.13.2.orig/src/rdkafka_conf.c	2026-04-08 13:20:01.569542436 +0200
-+++ librdkafka-2.13.2/src/rdkafka_conf.c	2026-04-08 15:31:46.990862860 +0200
+--- librdkafka-2.13.2.orig/src/rdkafka_conf.c	2026-02-26 08:38:12.000000000 +0100
++++ librdkafka-2.13.2/src/rdkafka_conf.c	2026-04-09 10:50:38.276831668 +0200
 @@ -659,6 +659,15 @@
       "register a stats callback using `rd_kafka_conf_set_stats_cb()`. "
       "The granularity is 1000ms. A value of 0 disables statistics.",
@@ -186,8 +249,8 @@
      {_RK_GLOBAL, "enabled_events", _RK_C_INT, _RK(enabled_events),
       "See `rd_kafka_conf_set_events()`", 0, 0x7fffffff, 0},
      {_RK_GLOBAL, "error_cb", _RK_C_PTR, _RK(error_cb),
---- librdkafka-2.13.2.orig/src/rdkafka_conf.h	2026-04-08 13:20:01.569622045 +0200
-+++ librdkafka-2.13.2/src/rdkafka_conf.h	2026-04-08 13:20:09.417593578 +0200
+--- librdkafka-2.13.2.orig/src/rdkafka_conf.h	2026-02-26 08:38:12.000000000 +0100
++++ librdkafka-2.13.2/src/rdkafka_conf.h	2026-04-09 10:50:38.277417780 +0200
 @@ -248,6 +248,7 @@
          char *client_id_str;
          char *brokerlist;

--- a/dist/patches/rdkafka_stats_filter.patch
+++ b/dist/patches/rdkafka_stats_filter.patch
@@ -1,0 +1,198 @@
+--- librdkafka-2.13.2.orig/src/rdkafka.c	2026-04-08 13:20:01.569341019 +0200
++++ librdkafka-2.13.2/src/rdkafka.c	2026-04-08 13:20:57.667328799 +0200
+@@ -1476,6 +1476,29 @@
+ }
+ 
+ /**
++ * @brief Accumulate partition counters into totals without emitting JSON.
++ *
++ * Used when a partition is filtered from statistics output but its counters
++ * must still contribute to the root-level aggregate totals.
++ *
++ * @param total Pointer to totals struct, or NULL to skip accumulation.
++ * @param rktp Partition to accumulate counters from.
++ */
++static RD_INLINE void
++rd_kafka_stats_accum_toppar(struct _stats_total *total,
++                            rd_kafka_toppar_t *rktp) {
++        if (!total)
++                return;
++
++        rd_kafka_toppar_lock(rktp);
++        total->txmsgs += rd_atomic64_get(&rktp->rktp_c.tx_msgs);
++        total->txmsg_bytes += rd_atomic64_get(&rktp->rktp_c.tx_msg_bytes);
++        total->rxmsgs += rd_atomic64_get(&rktp->rktp_c.rx_msgs);
++        total->rxmsg_bytes += rd_atomic64_get(&rktp->rktp_c.rx_msg_bytes);
++        rd_kafka_toppar_unlock(rktp);
++}
++
++/**
+  * Emit stats for toppar
+  */
+ static RD_INLINE void rd_kafka_stats_emit_toppar(struct _stats_emit *st,
+@@ -1922,52 +1945,96 @@
+         }
+ 
+ 
+-        _st_printf(
+-            "}, " /* close "brokers" array */
+-            "\"topics\":{ ");
++        if (!rk->rk_conf.stats_include_unassigned &&
++            rk->rk_type == RD_KAFKA_PRODUCER) {
++                /* Producer with unassigned excluded: skip all topic/partition
++                 * JSON, only accumulate counters for root-level totals. */
++                _st_printf(
++                    "}, " /* close "brokers" array */
++                    "\"topics\":{ ");
+ 
+-        TAILQ_FOREACH(rkt, &rk->rk_topics, rkt_link) {
+-                rd_kafka_toppar_t *rktp;
+-                int i, j;
++                TAILQ_FOREACH(rkt, &rk->rk_topics, rkt_link) {
++                        rd_kafka_toppar_t *rktp;
++                        int i, j;
+ 
+-                rd_kafka_topic_rdlock(rkt);
+-                _st_printf(
+-                    "%s\"%.*s\": { "
+-                    "\"topic\":\"%.*s\", "
+-                    "\"age\":%" PRId64
+-                    ", "
+-                    "\"metadata_age\":%" PRId64 ", ",
+-                    rkt == TAILQ_FIRST(&rk->rk_topics) ? "" : ", ",
+-                    RD_KAFKAP_STR_PR(rkt->rkt_topic),
+-                    RD_KAFKAP_STR_PR(rkt->rkt_topic),
+-                    (now - rkt->rkt_ts_create) / 1000,
+-                    rkt->rkt_ts_metadata ? (now - rkt->rkt_ts_metadata) / 1000
+-                                         : 0);
+-
+-                rd_kafka_stats_emit_avg(st, "batchsize",
+-                                        &rkt->rkt_avg_batchsize);
+-                rd_kafka_stats_emit_avg(st, "batchcnt", &rkt->rkt_avg_batchcnt);
+-
+-                _st_printf("\"partitions\":{ " /*open partitions*/);
+-
+-                for (i = 0; i < rkt->rkt_partition_cnt; i++)
+-                        rd_kafka_stats_emit_toppar(st, &total, rkt->rkt_p[i],
+-                                                   i == 0);
+-
+-                RD_LIST_FOREACH(rktp, &rkt->rkt_desp, j)
+-                rd_kafka_stats_emit_toppar(st, &total, rktp, i + j == 0);
+-
+-                i += j;
+-
+-                if (rkt->rkt_ua)
+-                        rd_kafka_stats_emit_toppar(st, NULL, rkt->rkt_ua,
+-                                                   i++ == 0);
++                        rd_kafka_topic_rdlock(rkt);
+ 
+-                rd_kafka_topic_rdunlock(rkt);
++                        for (i = 0; i < rkt->rkt_partition_cnt; i++)
++                                rd_kafka_stats_accum_toppar(&total,
++                                                            rkt->rkt_p[i]);
++
++                        RD_LIST_FOREACH(rktp, &rkt->rkt_desp, j)
++                        rd_kafka_stats_accum_toppar(&total, rktp);
++
++                        rd_kafka_topic_rdunlock(rkt);
++                }
++        } else {
++                /* Consumer or unfiltered: emit topics with optional
++                 * per-partition filtering for consumers. */
++                int filter_unassigned = !rk->rk_conf.stats_include_unassigned;
+ 
+                 _st_printf(
+-                    "} " /*close partitions*/
+-                    "} " /*close topic*/);
++                    "}, " /* close "brokers" array */
++                    "\"topics\":{ ");
++
++                TAILQ_FOREACH(rkt, &rk->rk_topics, rkt_link) {
++                        rd_kafka_toppar_t *rktp;
++                        int i, j;
++                        int first_partition;
++
++                        rd_kafka_topic_rdlock(rkt);
++                        _st_printf(
++                            "%s\"%.*s\": { "
++                            "\"topic\":\"%.*s\", "
++                            "\"age\":%" PRId64
++                            ", "
++                            "\"metadata_age\":%" PRId64 ", ",
++                            rkt == TAILQ_FIRST(&rk->rk_topics) ? "" : ", ",
++                            RD_KAFKAP_STR_PR(rkt->rkt_topic),
++                            RD_KAFKAP_STR_PR(rkt->rkt_topic),
++                            (now - rkt->rkt_ts_create) / 1000,
++                            rkt->rkt_ts_metadata
++                                ? (now - rkt->rkt_ts_metadata) / 1000
++                                : 0);
++
++                        rd_kafka_stats_emit_avg(st, "batchsize",
++                                                &rkt->rkt_avg_batchsize);
++                        rd_kafka_stats_emit_avg(st, "batchcnt",
++                                                &rkt->rkt_avg_batchcnt);
++
++                        _st_printf("\"partitions\":{ " /*open partitions*/);
++
++                        first_partition = 1;
++                        for (i = 0; i < rkt->rkt_partition_cnt; i++) {
++                                if (filter_unassigned &&
++                                    !RD_KAFKA_TOPPAR_FETCH_IS_STARTED(
++                                        rkt->rkt_p[i]->rktp_fetch_state)) {
++                                        rd_kafka_stats_accum_toppar(
++                                            &total, rkt->rkt_p[i]);
++                                        continue;
++                                }
++                                rd_kafka_stats_emit_toppar(
++                                    st, &total, rkt->rkt_p[i], first_partition);
++                                first_partition = 0;
++                        }
++
++                        RD_LIST_FOREACH(rktp, &rkt->rkt_desp, j) {
++                                rd_kafka_stats_emit_toppar(
++                                    st, &total, rktp,
++                                    first_partition && (j == 0));
++                                first_partition = 0;
++                        }
++
++                        if (rkt->rkt_ua)
++                                rd_kafka_stats_emit_toppar(
++                                    st, NULL, rkt->rkt_ua, first_partition);
++
++                        rd_kafka_topic_rdunlock(rkt);
++
++                        _st_printf(
++                            "} " /*close partitions*/
++                            "} " /*close topic*/);
++                }
+         }
+         _st_printf("} " /*close topics*/);
+ 
+--- librdkafka-2.13.2.orig/src/rdkafka_conf.c	2026-04-08 13:20:01.569542436 +0200
++++ librdkafka-2.13.2/src/rdkafka_conf.c	2026-04-08 15:31:46.990862860 +0200
+@@ -659,6 +659,15 @@
+      "register a stats callback using `rd_kafka_conf_set_stats_cb()`. "
+      "The granularity is 1000ms. A value of 0 disables statistics.",
+      0, 86400 * 1000, 0},
++    {_RK_GLOBAL, "statistics.unassigned.include", _RK_C_BOOL,
++     _RK(stats_include_unassigned),
++     "Include unassigned partitions in statistics output. "
++     "When set to false, consumers will exclude partitions whose fetch "
++     "state has not started (unassigned) from the statistics JSON, while "
++     "producers will emit an empty topics section. Partition counters "
++     "still contribute to root-level totals in both cases. "
++     "Reduces statistics JSON size significantly on large clusters.",
++     0, 1, 1},
+     {_RK_GLOBAL, "enabled_events", _RK_C_INT, _RK(enabled_events),
+      "See `rd_kafka_conf_set_events()`", 0, 0x7fffffff, 0},
+     {_RK_GLOBAL, "error_cb", _RK_C_PTR, _RK(error_cb),
+--- librdkafka-2.13.2.orig/src/rdkafka_conf.h	2026-04-08 13:20:01.569622045 +0200
++++ librdkafka-2.13.2/src/rdkafka_conf.h	2026-04-08 13:20:09.417593578 +0200
+@@ -248,6 +248,7 @@
+         char *client_id_str;
+         char *brokerlist;
+         int stats_interval_ms;
++        int stats_include_unassigned;
+         int term_sig;
+         int reconnect_backoff_ms;
+         int reconnect_backoff_max_ms;

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -2,7 +2,7 @@
 
 module Rdkafka
   # Current rdkafka-ruby gem version
-  VERSION = "0.25.0"
+  VERSION = "0.25.1"
   # Target librdkafka version to be used
   LIBRDKAFKA_VERSION = "2.13.2"
   # SHA256 hash of the librdkafka source tarball for verification

--- a/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
@@ -106,9 +106,11 @@ latest_by_name.each do |name, data|
   all_ok = false
 end
 
-avg_json_size = total_json_size / latest_by_name.size
 puts "  Total reported: #{total_reported}"
-puts "  Avg JSON size per consumer: #{avg_json_size} bytes"
+unless latest_by_name.empty?
+  avg_json_size = total_json_size / latest_by_name.size
+  puts "  Avg JSON size per consumer: #{avg_json_size} bytes"
+end
 puts
 
 if latest_by_name.size < CONSUMER_COUNT

--- a/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
@@ -13,6 +13,14 @@
 require "rdkafka"
 require "securerandom"
 require "json"
+require "socket"
+
+# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
+begin
+  TCPSocket.new("localhost", 9092).close
+rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+  exit(0)
+end
 
 $stdout.sync = true
 

--- a/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# This integration test verifies that with statistics.unassigned.include=false
+# and 10 consumers in the same group, each consumer only reports its assigned
+# partitions (~100 each out of 1000 total).
+#
+# Requires a running Kafka broker at localhost:9092.
+#
+# Exit codes:
+# - 0: Each consumer reports only its assigned partitions (test passes)
+# - 1: Partition counts don't match expectations (test fails)
+
+require "rdkafka"
+require "securerandom"
+require "json"
+
+$stdout.sync = true
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "stats-integration-cg-filtered-#{SecureRandom.hex(6)}"
+PARTITIONS = 1_000
+CONSUMER_COUNT = 10
+
+admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
+admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
+
+10.times do
+  admin.metadata(TOPIC)
+  break
+rescue Rdkafka::RdkafkaError
+  sleep 0.5
+end
+
+group_id = "stats-group-filtered-#{SecureRandom.hex(4)}"
+all_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { all_stats << published }
+
+consumers = CONSUMER_COUNT.times.map do
+  Rdkafka::Config.new(
+    "bootstrap.servers": BOOTSTRAP,
+    "group.id": group_id,
+    "auto.offset.reset": "earliest",
+    "statistics.interval.ms": 500,
+    "statistics.unassigned.include": false
+  ).consumer
+end
+
+consumers.each { |c| c.subscribe(TOPIC) }
+
+# Poll all consumers until each has reported partition data in stats.
+# Use the "name" field to identify per-consumer stats.
+(120 * 20).times do
+  consumers.each do |c|
+    c.poll(25)
+  rescue Rdkafka::RdkafkaError
+    nil
+  end
+
+  names_with_partitions = all_stats
+    .select { |s| (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 1 }
+    .map { |s| s["name"] }
+    .uniq
+
+  break if names_with_partitions.size >= CONSUMER_COUNT
+end
+
+consumers.each(&:close)
+Rdkafka::Config.statistics_callback = nil
+
+# --- Cleanup ---
+begin
+  admin.delete_topic(TOPIC).wait(max_wait_timeout_ms: 15_000)
+rescue Rdkafka::RdkafkaError
+  nil
+end
+admin.close
+
+# --- Results ---
+# Group latest stats by consumer name, pick only those with partition data
+latest_by_name = {}
+all_stats.each do |s|
+  topic_data = (s["topics"][TOPIC] || {}).fetch("partitions", {})
+  next if topic_data.empty?
+
+  latest_by_name[s["name"]] = {
+    partitions: topic_data.keys.count { |k| k != "-1" },
+    json_size: JSON.generate(s).bytesize
+  }
+end
+
+puts
+puts "#{CONSUMER_COUNT} consumers, #{PARTITIONS} partitions, filter enabled:"
+
+total_reported = 0
+total_json_size = 0
+all_ok = true
+
+latest_by_name.each do |name, data|
+  puts "  #{name}: #{data[:partitions]} partitions, #{data[:json_size]} bytes"
+  total_reported += data[:partitions]
+  total_json_size += data[:json_size]
+
+  next if data[:partitions] > 0 && data[:partitions] < PARTITIONS
+
+  puts "  FAIL: Expected partial assignment, got #{data[:partitions]}"
+  all_ok = false
+end
+
+avg_json_size = total_json_size / latest_by_name.size
+puts "  Total reported: #{total_reported}"
+puts "  Avg JSON size per consumer: #{avg_json_size} bytes"
+puts
+
+if latest_by_name.size < CONSUMER_COUNT
+  puts "FAIL: Only #{latest_by_name.size}/#{CONSUMER_COUNT} consumers reported partition data"
+  exit(1)
+elsif !all_ok
+  puts "FAIL: Some consumers reported unexpected partition counts"
+  exit(1)
+elsif total_reported >= PARTITIONS
+  puts "PASS: All #{CONSUMER_COUNT} consumers report only assigned partitions (#{total_reported} total)"
+  exit(0)
+else
+  puts "FAIL: Total reported partitions (#{total_reported}) less than #{PARTITIONS}"
+  exit(1)
+end

--- a/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_filtered_spec.rb
@@ -13,14 +13,6 @@
 require "rdkafka"
 require "securerandom"
 require "json"
-require "socket"
-
-# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
-begin
-  TCPSocket.new("localhost", 9092).close
-rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
-  exit(0)
-end
 
 $stdout.sync = true
 

--- a/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# This integration test verifies that with statistics.unassigned.include=true
+# (default) and 10 consumers in the same group, each consumer reports ALL 1000
+# partitions — including the ~900 it does not own.
+#
+# This contrasts with the filtered variant where each consumer only reports
+# its ~100 assigned partitions.
+#
+# Requires a running Kafka broker at localhost:9092.
+#
+# Exit codes:
+# - 0: Each consumer reports all partitions (test passes)
+# - 1: Some consumers are missing partitions (test fails)
+
+require "rdkafka"
+require "securerandom"
+require "json"
+
+$stdout.sync = true
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "stats-integration-cg-unfiltered-#{SecureRandom.hex(6)}"
+PARTITIONS = 1_000
+CONSUMER_COUNT = 10
+
+admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
+admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
+
+10.times do
+  admin.metadata(TOPIC)
+  break
+rescue Rdkafka::RdkafkaError
+  sleep 0.5
+end
+
+group_id = "stats-group-unfiltered-#{SecureRandom.hex(4)}"
+all_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { all_stats << published }
+
+consumers = CONSUMER_COUNT.times.map do
+  Rdkafka::Config.new(
+    "bootstrap.servers": BOOTSTRAP,
+    "group.id": group_id,
+    "auto.offset.reset": "earliest",
+    "statistics.interval.ms": 500,
+    "statistics.unassigned.include": true
+  ).consumer
+end
+
+consumers.each { |c| c.subscribe(TOPIC) }
+
+# Poll all consumers until each has reported all partitions in stats.
+(120 * 20).times do
+  consumers.each do |c|
+    c.poll(25)
+  rescue Rdkafka::RdkafkaError
+    nil
+  end
+
+  names_with_all = all_stats
+    .select { |s| (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100 }
+    .map { |s| s["name"] }
+    .uniq
+
+  break if names_with_all.size >= CONSUMER_COUNT
+end
+
+consumers.each(&:close)
+Rdkafka::Config.statistics_callback = nil
+
+# --- Cleanup ---
+begin
+  admin.delete_topic(TOPIC).wait(max_wait_timeout_ms: 15_000)
+rescue Rdkafka::RdkafkaError
+  nil
+end
+admin.close
+
+# --- Results ---
+latest_by_name = {}
+all_stats.each do |s|
+  topic_data = (s["topics"][TOPIC] || {}).fetch("partitions", {})
+  count = topic_data.keys.count { |k| k != "-1" }
+  next if count == 0
+
+  latest_by_name[s["name"]] = {
+    partitions: count,
+    json_size: JSON.generate(s).bytesize
+  }
+end
+
+puts
+puts "#{CONSUMER_COUNT} consumers, #{PARTITIONS} partitions, filter disabled:"
+
+all_ok = true
+
+latest_by_name.each do |name, data|
+  puts "  #{name}: #{data[:partitions]} partitions, #{data[:json_size]} bytes"
+
+  next if data[:partitions] >= PARTITIONS
+
+  puts "  FAIL: Expected #{PARTITIONS} partitions, got #{data[:partitions]}"
+  all_ok = false
+end
+
+total_json_size = latest_by_name.values.sum { |d| d[:json_size] }
+avg_json_size = total_json_size / latest_by_name.size
+puts "  Avg JSON size per consumer: #{avg_json_size} bytes"
+
+puts
+
+if latest_by_name.size < CONSUMER_COUNT
+  puts "FAIL: Only #{latest_by_name.size}/#{CONSUMER_COUNT} consumers reported partition data"
+  exit(1)
+elsif all_ok
+  puts "PASS: All #{CONSUMER_COUNT} consumers report all #{PARTITIONS} partitions"
+  exit(0)
+else
+  puts "FAIL: Some consumers did not report all partitions"
+  exit(1)
+end

--- a/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
@@ -16,14 +16,6 @@
 require "rdkafka"
 require "securerandom"
 require "json"
-require "socket"
-
-# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
-begin
-  TCPSocket.new("localhost", 9092).close
-rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
-  exit(0)
-end
 
 $stdout.sync = true
 

--- a/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
@@ -104,9 +104,11 @@ latest_by_name.each do |name, data|
   all_ok = false
 end
 
-total_json_size = latest_by_name.values.sum { |d| d[:json_size] }
-avg_json_size = total_json_size / latest_by_name.size
-puts "  Avg JSON size per consumer: #{avg_json_size} bytes"
+unless latest_by_name.empty?
+  total_json_size = latest_by_name.values.sum { |d| d[:json_size] }
+  avg_json_size = total_json_size / latest_by_name.size
+  puts "  Avg JSON size per consumer: #{avg_json_size} bytes"
+end
 
 puts
 

--- a/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_group_unfiltered_spec.rb
@@ -16,6 +16,14 @@
 require "rdkafka"
 require "securerandom"
 require "json"
+require "socket"
+
+# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
+begin
+  TCPSocket.new("localhost", 9092).close
+rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+  exit(0)
+end
 
 $stdout.sync = true
 

--- a/spec/integrations/statistics_unassigned_consumer_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# This integration test measures the statistics JSON size reduction when using
+# statistics.unassigned.include=false for a consumer with a 1000-partition topic.
+#
+# Requires a running Kafka broker at localhost:9092.
+#
+# Exit codes:
+# - 0: Filtered stats are significantly smaller (test passes)
+# - 1: No significant reduction or error (test fails)
+
+require "rdkafka"
+require "securerandom"
+require "json"
+
+$stdout.sync = true
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "stats-integration-consumer-#{SecureRandom.hex(6)}"
+PARTITIONS = 1_000
+
+puts "Creating topic #{TOPIC} with #{PARTITIONS} partitions..."
+
+admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
+admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
+
+10.times do
+  admin.metadata(TOPIC)
+  break
+rescue Rdkafka::RdkafkaError
+  sleep 0.5
+end
+
+
+puts "Topic created."
+
+poll_until = ->(consumer, target, &condition) {
+  (30 * 20).times do
+    break if condition.call(target)
+    begin
+      consumer.poll(50)
+    rescue Rdkafka::RdkafkaError
+      nil
+    end
+  end
+}
+
+# --- Unfiltered consumer (run first to wait for metadata) ---
+unfiltered_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { unfiltered_stats << published }
+
+unfiltered_consumer = Rdkafka::Config.new(
+  "bootstrap.servers": BOOTSTRAP,
+  "group.id": "stats-unfiltered-#{SecureRandom.hex(4)}",
+  "auto.offset.reset": "earliest",
+  "statistics.interval.ms": 100,
+  "statistics.unassigned.include": true
+).consumer
+
+unfiltered_consumer.subscribe(TOPIC)
+poll_until.call(unfiltered_consumer, unfiltered_stats) { |s|
+  s.any? { |stat| (stat["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100 }
+}
+unfiltered_consumer.close
+
+# --- Filtered consumer ---
+filtered_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { filtered_stats << published }
+
+filtered_consumer = Rdkafka::Config.new(
+  "bootstrap.servers": BOOTSTRAP,
+  "group.id": "stats-filtered-#{SecureRandom.hex(4)}",
+  "auto.offset.reset": "earliest",
+  "statistics.interval.ms": 100,
+  "statistics.unassigned.include": false
+).consumer
+
+filtered_consumer.subscribe(TOPIC)
+poll_until.call(filtered_consumer, filtered_stats) { |s| s.size >= 2 }
+filtered_consumer.close
+
+Rdkafka::Config.statistics_callback = nil
+
+# --- Cleanup ---
+begin
+  admin.delete_topic(TOPIC).wait(max_wait_timeout_ms: 15_000)
+rescue Rdkafka::RdkafkaError
+  nil
+end
+admin.close
+
+# --- Results ---
+unfiltered_stat = unfiltered_stats.reverse.find do |s|
+  (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100
+end
+unfiltered_json = JSON.generate(unfiltered_stat)
+filtered_json = JSON.generate(filtered_stats.last)
+
+unfiltered_size = unfiltered_json.bytesize
+filtered_size = filtered_json.bytesize
+reduction = ((1.0 - filtered_size.to_f / unfiltered_size) * 100).round(1)
+
+puts
+puts "Consumer statistics JSON size (#{PARTITIONS} partitions):"
+puts "  Unfiltered: #{unfiltered_size} bytes"
+puts "  Filtered:   #{filtered_size} bytes"
+puts "  Reduction:  #{reduction}%"
+puts
+
+if filtered_size < unfiltered_size / 2
+  puts "PASS: Filtered stats are #{reduction}% smaller"
+  exit(0)
+else
+  puts "FAIL: Expected at least 50% reduction, got #{reduction}%"
+  exit(1)
+end

--- a/spec/integrations/statistics_unassigned_consumer_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
-# This integration test measures the statistics JSON size reduction when using
-# statistics.unassigned.include=false for a consumer with a 1000-partition topic.
+# This integration test verifies that a single consumer with
+# statistics.unassigned.include=false still reports all assigned partitions.
+#
+# A single consumer subscribes to a 1000-partition topic and gets all partitions
+# assigned. With the filter enabled, all partitions should still appear in the
+# statistics because they are assigned (fetch_state != none).
 #
 # Requires a running Kafka broker at localhost:9092.
 #
 # Exit codes:
-# - 0: Filtered stats are significantly smaller (test passes)
-# - 1: No significant reduction or error (test fails)
+# - 0: All assigned partitions are present in filtered stats (test passes)
+# - 1: Partitions are missing or error (test fails)
 
 require "rdkafka"
 require "securerandom"
@@ -19,8 +23,6 @@ BOOTSTRAP = "localhost:9092"
 TOPIC = "stats-integration-consumer-#{SecureRandom.hex(6)}"
 PARTITIONS = 1_000
 
-puts "Creating topic #{TOPIC} with #{PARTITIONS} partitions..."
-
 admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
 admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
 
@@ -31,39 +33,7 @@ rescue Rdkafka::RdkafkaError
   sleep 0.5
 end
 
-
-puts "Topic created."
-
-poll_until = ->(consumer, target, &condition) {
-  (30 * 20).times do
-    break if condition.call(target)
-    begin
-      consumer.poll(50)
-    rescue Rdkafka::RdkafkaError
-      nil
-    end
-  end
-}
-
-# --- Unfiltered consumer (run first to wait for metadata) ---
-unfiltered_stats = []
-Rdkafka::Config.statistics_callback = ->(published) { unfiltered_stats << published }
-
-unfiltered_consumer = Rdkafka::Config.new(
-  "bootstrap.servers": BOOTSTRAP,
-  "group.id": "stats-unfiltered-#{SecureRandom.hex(4)}",
-  "auto.offset.reset": "earliest",
-  "statistics.interval.ms": 100,
-  "statistics.unassigned.include": true
-).consumer
-
-unfiltered_consumer.subscribe(TOPIC)
-poll_until.call(unfiltered_consumer, unfiltered_stats) { |s|
-  s.any? { |stat| (stat["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100 }
-}
-unfiltered_consumer.close
-
-# --- Filtered consumer ---
+# --- Filtered consumer (all partitions should be assigned and reported) ---
 filtered_stats = []
 Rdkafka::Config.statistics_callback = ->(published) { filtered_stats << published }
 
@@ -76,9 +46,19 @@ filtered_consumer = Rdkafka::Config.new(
 ).consumer
 
 filtered_consumer.subscribe(TOPIC)
-poll_until.call(filtered_consumer, filtered_stats) { |s| s.size >= 2 }
-filtered_consumer.close
 
+(60 * 20).times do
+  break if filtered_stats.any? { |s|
+    (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100
+  }
+  begin
+    filtered_consumer.poll(50)
+  rescue Rdkafka::RdkafkaError
+    nil
+  end
+end
+
+filtered_consumer.close
 Rdkafka::Config.statistics_callback = nil
 
 # --- Cleanup ---
@@ -90,27 +70,28 @@ end
 admin.close
 
 # --- Results ---
-unfiltered_stat = unfiltered_stats.reverse.find do |s|
+filtered_stat = filtered_stats.reverse.find do |s|
   (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100
 end
-unfiltered_json = JSON.generate(unfiltered_stat)
-filtered_json = JSON.generate(filtered_stats.last)
 
-unfiltered_size = unfiltered_json.bytesize
-filtered_size = filtered_json.bytesize
-reduction = ((1.0 - filtered_size.to_f / unfiltered_size) * 100).round(1)
+if filtered_stat.nil?
+  puts "FAIL: No stats with partition data found"
+  exit(1)
+end
+
+partitions = filtered_stat["topics"][TOPIC]["partitions"]
+partition_count = partitions.keys.count { |k| k != "-1" }
 
 puts
-puts "Consumer statistics JSON size (#{PARTITIONS} partitions):"
-puts "  Unfiltered: #{unfiltered_size} bytes"
-puts "  Filtered:   #{filtered_size} bytes"
-puts "  Reduction:  #{reduction}%"
+puts "Consumer with #{PARTITIONS} assigned partitions (filter enabled):"
+puts "  Partitions reported: #{partition_count}"
+puts "  JSON size:           #{JSON.generate(filtered_stat).bytesize} bytes"
 puts
 
-if filtered_size < unfiltered_size / 2
-  puts "PASS: Filtered stats are #{reduction}% smaller"
+if partition_count >= PARTITIONS
+  puts "PASS: All #{partition_count} assigned partitions present in filtered stats"
   exit(0)
 else
-  puts "FAIL: Expected at least 50% reduction, got #{reduction}%"
+  puts "FAIL: Expected #{PARTITIONS} partitions, got #{partition_count}"
   exit(1)
 end

--- a/spec/integrations/statistics_unassigned_consumer_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_spec.rb
@@ -13,15 +13,6 @@
 # - 0: All assigned partitions are present in filtered stats (test passes)
 # - 1: Partitions are missing or error (test fails)
 
-require "socket"
-
-# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
-begin
-  TCPSocket.new("localhost", 9092).close
-rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
-  exit(0)
-end
-
 require "rdkafka"
 require "securerandom"
 require "json"

--- a/spec/integrations/statistics_unassigned_consumer_spec.rb
+++ b/spec/integrations/statistics_unassigned_consumer_spec.rb
@@ -13,6 +13,15 @@
 # - 0: All assigned partitions are present in filtered stats (test passes)
 # - 1: Partitions are missing or error (test fails)
 
+require "socket"
+
+# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
+begin
+  TCPSocket.new("localhost", 9092).close
+rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+  exit(0)
+end
+
 require "rdkafka"
 require "securerandom"
 require "json"

--- a/spec/integrations/statistics_unassigned_producer_spec.rb
+++ b/spec/integrations/statistics_unassigned_producer_spec.rb
@@ -3,6 +3,9 @@
 # This integration test measures the statistics JSON size reduction when using
 # statistics.unassigned.include=false for a producer with a 1000-partition topic.
 #
+# Producers never own partitions, so all partition data is unassigned.
+# With the filter enabled, the topics section is empty, yielding significant savings.
+#
 # Requires a running Kafka broker at localhost:9092.
 #
 # Exit codes:
@@ -19,8 +22,6 @@ BOOTSTRAP = "localhost:9092"
 TOPIC = "stats-integration-producer-#{SecureRandom.hex(6)}"
 PARTITIONS = 1_000
 
-puts "Creating topic #{TOPIC} with #{PARTITIONS} partitions..."
-
 admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
 admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
 
@@ -31,13 +32,8 @@ rescue Rdkafka::RdkafkaError
   sleep 0.5
 end
 
-puts "Topic created."
-
-wait_for_stats = ->(target, count = 2) {
-  (10 * 20).times do
-    break if target.size >= count
-    sleep 0.05
-  end
+has_partitions = ->(stats) {
+  stats.any? { |s| (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100 }
 }
 
 # --- Unfiltered producer ---
@@ -51,7 +47,12 @@ unfiltered_producer = Rdkafka::Config.new(
 ).producer
 
 unfiltered_producer.produce(topic: TOPIC, payload: "test").wait
-wait_for_stats.call(unfiltered_stats)
+
+(30 * 20).times do
+  break if has_partitions.call(unfiltered_stats)
+  sleep 0.05
+end
+
 unfiltered_producer.close
 
 # --- Filtered producer ---
@@ -65,7 +66,12 @@ filtered_producer = Rdkafka::Config.new(
 ).producer
 
 filtered_producer.produce(topic: TOPIC, payload: "test").wait
-wait_for_stats.call(filtered_stats)
+
+(10 * 20).times do
+  break if filtered_stats.size >= 2
+  sleep 0.05
+end
+
 filtered_producer.close
 
 Rdkafka::Config.statistics_callback = nil
@@ -79,7 +85,10 @@ end
 admin.close
 
 # --- Results ---
-unfiltered_json = JSON.generate(unfiltered_stats.last)
+unfiltered_stat = unfiltered_stats.reverse.find do |s|
+  (s["topics"][TOPIC] || {}).fetch("partitions", {}).size > 100
+end
+unfiltered_json = JSON.generate(unfiltered_stat)
 filtered_json = JSON.generate(filtered_stats.last)
 
 unfiltered_size = unfiltered_json.bytesize

--- a/spec/integrations/statistics_unassigned_producer_spec.rb
+++ b/spec/integrations/statistics_unassigned_producer_spec.rb
@@ -13,14 +13,6 @@
 # - 1: No significant reduction or error (test fails)
 
 require "rdkafka"
-require "socket"
-
-# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
-begin
-  TCPSocket.new("localhost", 9092).close
-rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
-  exit(0)
-end
 require "securerandom"
 require "json"
 

--- a/spec/integrations/statistics_unassigned_producer_spec.rb
+++ b/spec/integrations/statistics_unassigned_producer_spec.rb
@@ -13,6 +13,14 @@
 # - 1: No significant reduction or error (test fails)
 
 require "rdkafka"
+require "socket"
+
+# Skip when no Kafka broker is available (e.g. complementary CI without Kafka)
+begin
+  TCPSocket.new("localhost", 9092).close
+rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+  exit(0)
+end
 require "securerandom"
 require "json"
 

--- a/spec/integrations/statistics_unassigned_producer_spec.rb
+++ b/spec/integrations/statistics_unassigned_producer_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# This integration test measures the statistics JSON size reduction when using
+# statistics.unassigned.include=false for a producer with a 1000-partition topic.
+#
+# Requires a running Kafka broker at localhost:9092.
+#
+# Exit codes:
+# - 0: Filtered stats are significantly smaller (test passes)
+# - 1: No significant reduction or error (test fails)
+
+require "rdkafka"
+require "securerandom"
+require "json"
+
+$stdout.sync = true
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "stats-integration-producer-#{SecureRandom.hex(6)}"
+PARTITIONS = 1_000
+
+puts "Creating topic #{TOPIC} with #{PARTITIONS} partitions..."
+
+admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
+admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
+
+10.times do
+  admin.metadata(TOPIC)
+  break
+rescue Rdkafka::RdkafkaError
+  sleep 0.5
+end
+
+puts "Topic created."
+
+wait_for_stats = ->(target, count = 2) {
+  (10 * 20).times do
+    break if target.size >= count
+    sleep 0.05
+  end
+}
+
+# --- Unfiltered producer ---
+unfiltered_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { unfiltered_stats << published }
+
+unfiltered_producer = Rdkafka::Config.new(
+  "bootstrap.servers": BOOTSTRAP,
+  "statistics.interval.ms": 100,
+  "statistics.unassigned.include": true
+).producer
+
+unfiltered_producer.produce(topic: TOPIC, payload: "test").wait
+wait_for_stats.call(unfiltered_stats)
+unfiltered_producer.close
+
+# --- Filtered producer ---
+filtered_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { filtered_stats << published }
+
+filtered_producer = Rdkafka::Config.new(
+  "bootstrap.servers": BOOTSTRAP,
+  "statistics.interval.ms": 100,
+  "statistics.unassigned.include": false
+).producer
+
+filtered_producer.produce(topic: TOPIC, payload: "test").wait
+wait_for_stats.call(filtered_stats)
+filtered_producer.close
+
+Rdkafka::Config.statistics_callback = nil
+
+# --- Cleanup ---
+begin
+  admin.delete_topic(TOPIC).wait(max_wait_timeout_ms: 15_000)
+rescue Rdkafka::RdkafkaError
+  nil
+end
+admin.close
+
+# --- Results ---
+unfiltered_json = JSON.generate(unfiltered_stats.last)
+filtered_json = JSON.generate(filtered_stats.last)
+
+unfiltered_size = unfiltered_json.bytesize
+filtered_size = filtered_json.bytesize
+reduction = ((1.0 - filtered_size.to_f / unfiltered_size) * 100).round(1)
+
+puts
+puts "Producer statistics JSON size (#{PARTITIONS} partitions):"
+puts "  Unfiltered: #{unfiltered_size} bytes"
+puts "  Filtered:   #{filtered_size} bytes"
+puts "  Reduction:  #{reduction}%"
+puts
+
+if filtered_size < unfiltered_size / 2
+  puts "PASS: Filtered stats are #{reduction}% smaller"
+  exit(0)
+else
+  puts "FAIL: Expected at least 50% reduction, got #{reduction}%"
+  exit(1)
+end

--- a/spec/integrations/statistics_unassigned_toppars_spec.rb
+++ b/spec/integrations/statistics_unassigned_toppars_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+# This integration test verifies that the statistics.unassigned.include=false
+# filter also reduces the size of the per-broker "toppars" section (a map of
+# topic-partitions leader-owned by each broker).
+#
+# With a 1000-partition topic and a filtered producer, each broker's toppars
+# map should be empty. A filtered consumer that has not yet been assigned
+# partitions should also report an empty toppars map. An unfiltered client
+# should populate toppars with all of its leader-owned partitions.
+#
+# Requires a running Kafka broker at localhost:9092.
+#
+# Exit codes:
+# - 0: toppars is filtered as expected and JSON shrinks significantly
+# - 1: toppars is not filtered, or no measurable reduction
+require "rdkafka"
+require "securerandom"
+require "json"
+
+$stdout.sync = true
+
+BOOTSTRAP = "localhost:9092"
+TOPIC = "stats-integration-toppars-#{SecureRandom.hex(6)}"
+PARTITIONS = 1_000
+
+admin = Rdkafka::Config.new("bootstrap.servers": BOOTSTRAP).admin
+admin.create_topic(TOPIC, PARTITIONS, 1).wait(max_wait_timeout_ms: 15_000)
+
+10.times do
+  admin.metadata(TOPIC)
+  break
+rescue Rdkafka::RdkafkaError
+  sleep 0.5
+end
+
+broker_has_topic_toppars = lambda do |stat|
+  stat["brokers"].any? do |_, broker|
+    (broker["toppars"] || {}).any? { |_, tp| tp["topic"] == TOPIC }
+  end
+end
+
+# --- Unfiltered producer: expect brokers.toppars populated ---
+unfiltered_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { unfiltered_stats << published }
+
+unfiltered_producer = Rdkafka::Config.new(
+  "bootstrap.servers": BOOTSTRAP,
+  "statistics.interval.ms": 100,
+  "statistics.unassigned.include": true
+).producer
+
+unfiltered_producer.produce(topic: TOPIC, payload: "test").wait
+
+(60 * 20).times do
+  break if unfiltered_stats.any?(&broker_has_topic_toppars)
+  sleep 0.05
+end
+
+unfiltered_producer.close
+
+# --- Filtered producer: expect brokers.toppars empty for this topic ---
+filtered_stats = []
+Rdkafka::Config.statistics_callback = ->(published) { filtered_stats << published }
+
+filtered_producer = Rdkafka::Config.new(
+  "bootstrap.servers": BOOTSTRAP,
+  "statistics.interval.ms": 100,
+  "statistics.unassigned.include": false
+).producer
+
+filtered_producer.produce(topic: TOPIC, payload: "test").wait
+
+(30 * 20).times do
+  break if filtered_stats.size >= 3
+  sleep 0.05
+end
+
+filtered_producer.close
+Rdkafka::Config.statistics_callback = nil
+
+# --- Cleanup ---
+begin
+  admin.delete_topic(TOPIC).wait(max_wait_timeout_ms: 15_000)
+rescue Rdkafka::RdkafkaError
+  nil
+end
+admin.close
+
+# --- Results ---
+unfiltered_stat = unfiltered_stats.reverse.find(&broker_has_topic_toppars)
+
+if unfiltered_stat.nil?
+  puts "FAIL: No unfiltered stat reported brokers.toppars for #{TOPIC}"
+  exit(1)
+end
+
+unfiltered_toppars_count = unfiltered_stat["brokers"].sum do |_, broker|
+  (broker["toppars"] || {}).count { |_, tp| tp["topic"] == TOPIC }
+end
+
+filtered_stat = filtered_stats.last
+
+if filtered_stat.nil?
+  puts "FAIL: No filtered stats captured"
+  exit(1)
+end
+
+filtered_toppars_leak = filtered_stat["brokers"].any? do |_, broker|
+  (broker["toppars"] || {}).any? { |_, tp| tp["topic"] == TOPIC }
+end
+
+unfiltered_size = JSON.generate(unfiltered_stat).bytesize
+filtered_size = JSON.generate(filtered_stat).bytesize
+reduction = ((1.0 - filtered_size.to_f / unfiltered_size) * 100).round(1)
+
+puts
+puts "Producer brokers.toppars filtering (#{PARTITIONS} partitions):"
+puts "  Unfiltered toppars for #{TOPIC}: #{unfiltered_toppars_count}"
+puts "  Filtered toppars for #{TOPIC}:   #{filtered_toppars_leak ? "LEAKED" : 0}"
+puts "  Unfiltered JSON size:            #{unfiltered_size} bytes"
+puts "  Filtered JSON size:              #{filtered_size} bytes"
+puts "  Reduction:                       #{reduction}%"
+puts
+
+if filtered_toppars_leak
+  puts "FAIL: Filtered producer stats still contain toppars for #{TOPIC}"
+  exit(1)
+elsif unfiltered_toppars_count < 1
+  puts "FAIL: Unfiltered producer stats reported zero toppars for #{TOPIC}"
+  exit(1)
+elsif filtered_size >= unfiltered_size
+  puts "FAIL: Filtered JSON is not smaller (#{filtered_size} >= #{unfiltered_size})"
+  exit(1)
+else
+  puts "PASS: brokers.toppars filtered and JSON #{reduction}% smaller"
+  exit(0)
+end

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -732,7 +732,7 @@ RSpec.describe Rdkafka::Admin do
             end
             sleep(1)
           end
-          expect(found).to eq(true), "Expected ACL for #{acl_name} to become visible"
+          expect(found).to be(true), "Expected ACL for #{acl_name} to become visible"
         end
 
         # Clean up created ACLs to avoid leaking state to other tests
@@ -916,7 +916,7 @@ RSpec.describe Rdkafka::Admin do
             end
             sleep(1)
           end
-          expect(found).to eq(true), "Expected transactional_id ACL for #{acl_name} to become visible"
+          expect(found).to be(true), "Expected transactional_id ACL for #{acl_name} to become visible"
         end
 
         # Clean up created ACLs to avoid leaking state to other tests

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -705,15 +705,6 @@ RSpec.describe Rdkafka::Admin do
       end
 
       it "create acls and describe the newly created acls" do
-        # Clean up any leftover ACLs from previous tests so that the broad
-        # describe filter below only sees the ones we create in this example.
-        begin
-          cleanup_handle = admin.delete_acl(resource_type: resource_type, resource_name: nil, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
-          cleanup_handle.wait(max_wait_timeout_ms: 15_000)
-        rescue
-          # Ignore errors if nothing to clean up
-        end
-
         acl_names = [TestTopics.unique, TestTopics.unique]
 
         # create_acl
@@ -724,20 +715,25 @@ RSpec.describe Rdkafka::Admin do
           expect(create_acl_report.rdkafka_response_string).to eq("")
         end
 
-        # Poll describe_acl until both ACLs are visible. ACL propagation on
-        # slow (especially emulated aarch64) CI runners can take several
-        # seconds, so a fixed sleep is unreliable.
-        describe_acl_report = nil
-        describe_acl_handle = nil
-        30.times do
-          describe_acl_handle = admin.describe_acl(resource_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_ANY, resource_name: nil, resource_pattern_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_ANY, principal: nil, host: nil, operation: Rdkafka::Bindings::RD_KAFKA_ACL_OPERATION_ANY, permission_type: Rdkafka::Bindings::RD_KAFKA_ACL_PERMISSION_TYPE_ANY)
-          describe_acl_report = describe_acl_handle.wait(max_wait_timeout_ms: 15_000)
-          break if describe_acl_report.acls.length >= 2
-          sleep(0.5)
+        # describe_acl - poll each ACL by its specific name. The broker's
+        # authorizer cache can lag the create_acl ACK by a few seconds on
+        # fast runners, and by much longer on QEMU-emulated aarch64 CI
+        # runners, so a single describe with a shared filter is unreliable.
+        # Polling each name individually is deterministic and robust to
+        # leftover state from other tests running in the same process.
+        acl_names.each do |acl_name|
+          found = false
+          60.times do
+            handle = admin.describe_acl(resource_type: resource_type, resource_name: acl_name, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+            report = handle.wait(max_wait_timeout_ms: 15_000)
+            if report.acls.any? { |a| a.matching_acl_resource_name == acl_name }
+              found = true
+              break
+            end
+            sleep(1)
+          end
+          expect(found).to eq(true), "Expected ACL for #{acl_name} to become visible"
         end
-
-        expect(describe_acl_handle[:response]).to eq(0)
-        expect(describe_acl_report.acls.length).to eq(2)
 
         # Clean up created ACLs to avoid leaking state to other tests
         acl_names.each do |acl_name|
@@ -879,56 +875,63 @@ RSpec.describe Rdkafka::Admin do
       end
 
       it "creates acls and describes the newly created transactional_id acls" do
-        # Create first ACL
-        create_acl_handle = admin.create_acl(
-          resource_type: transactional_id_resource_type,
-          resource_name: TestTopics.unique,
-          resource_pattern_type: transactional_id_resource_pattern_type,
-          principal: transactional_id_principal,
-          host: transactional_id_host,
-          operation: transactional_id_operation,
-          permission_type: transactional_id_permission_type
-        )
-        create_acl_report = create_acl_handle.wait(max_wait_timeout_ms: 15_000)
-        expect(create_acl_report.rdkafka_response).to eq(0)
-        expect(create_acl_report.rdkafka_response_string).to eq("")
+        acl_names = [TestTopics.unique, TestTopics.unique]
 
-        # Create second ACL
-        create_acl_handle = admin.create_acl(
-          resource_type: transactional_id_resource_type,
-          resource_name: TestTopics.unique,
-          resource_pattern_type: transactional_id_resource_pattern_type,
-          principal: transactional_id_principal,
-          host: transactional_id_host,
-          operation: transactional_id_operation,
-          permission_type: transactional_id_permission_type
-        )
-        create_acl_report = create_acl_handle.wait(max_wait_timeout_ms: 15_000)
-        expect(create_acl_report.rdkafka_response).to eq(0)
-        expect(create_acl_report.rdkafka_response_string).to eq("")
-
-        # Poll describe_acl until both ACLs are visible. ACL propagation on
-        # slow (especially emulated aarch64) CI runners can take several
-        # seconds, so a fixed sleep is unreliable.
-        describe_acl_report = nil
-        describe_acl_handle = nil
-        30.times do
-          describe_acl_handle = admin.describe_acl(
+        # Create both ACLs
+        acl_names.each do |acl_name|
+          create_acl_handle = admin.create_acl(
             resource_type: transactional_id_resource_type,
-            resource_name: nil,
-            resource_pattern_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_ANY,
+            resource_name: acl_name,
+            resource_pattern_type: transactional_id_resource_pattern_type,
             principal: transactional_id_principal,
             host: transactional_id_host,
             operation: transactional_id_operation,
             permission_type: transactional_id_permission_type
           )
-          describe_acl_report = describe_acl_handle.wait(max_wait_timeout_ms: 15_000)
-          break if describe_acl_report.acls.length >= 2
-          sleep(0.5)
+          create_acl_report = create_acl_handle.wait(max_wait_timeout_ms: 15_000)
+          expect(create_acl_report.rdkafka_response).to eq(0)
+          expect(create_acl_report.rdkafka_response_string).to eq("")
         end
 
-        expect(describe_acl_handle[:response]).to eq(0)
-        expect(describe_acl_report.acls.length).to eq(2)
+        # describe_acl - poll each ACL by its specific name. The broker's
+        # authorizer cache can lag the create_acl ACK by a few seconds on
+        # fast runners, and by much longer on QEMU-emulated aarch64 CI
+        # runners, so a single describe with a shared filter is unreliable.
+        acl_names.each do |acl_name|
+          found = false
+          60.times do
+            handle = admin.describe_acl(
+              resource_type: transactional_id_resource_type,
+              resource_name: acl_name,
+              resource_pattern_type: transactional_id_resource_pattern_type,
+              principal: transactional_id_principal,
+              host: transactional_id_host,
+              operation: transactional_id_operation,
+              permission_type: transactional_id_permission_type
+            )
+            report = handle.wait(max_wait_timeout_ms: 15_000)
+            if report.acls.any? { |a| a.matching_acl_resource_name == acl_name }
+              found = true
+              break
+            end
+            sleep(1)
+          end
+          expect(found).to eq(true), "Expected transactional_id ACL for #{acl_name} to become visible"
+        end
+
+        # Clean up created ACLs to avoid leaking state to other tests
+        acl_names.each do |acl_name|
+          delete_acl_handle = admin.delete_acl(
+            resource_type: transactional_id_resource_type,
+            resource_name: acl_name,
+            resource_pattern_type: transactional_id_resource_pattern_type,
+            principal: transactional_id_principal,
+            host: transactional_id_host,
+            operation: transactional_id_operation,
+            permission_type: transactional_id_permission_type
+          )
+          delete_acl_handle.wait(max_wait_timeout_ms: 15_000)
+        end
       end
     end
 

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -705,6 +705,15 @@ RSpec.describe Rdkafka::Admin do
       end
 
       it "create acls and describe the newly created acls" do
+        # Clean up any leftover ACLs from previous tests so that the broad
+        # describe filter below only sees the ones we create in this example.
+        begin
+          cleanup_handle = admin.delete_acl(resource_type: resource_type, resource_name: nil, resource_pattern_type: resource_pattern_type, principal: principal, host: host, operation: operation, permission_type: permission_type)
+          cleanup_handle.wait(max_wait_timeout_ms: 15_000)
+        rescue
+          # Ignore errors if nothing to clean up
+        end
+
         acl_names = [TestTopics.unique, TestTopics.unique]
 
         # create_acl
@@ -715,12 +724,18 @@ RSpec.describe Rdkafka::Admin do
           expect(create_acl_report.rdkafka_response_string).to eq("")
         end
 
-        # Since we create and immediately check, this is slow on loaded CIs, hence we wait
-        sleep(2)
+        # Poll describe_acl until both ACLs are visible. ACL propagation on
+        # slow (especially emulated aarch64) CI runners can take several
+        # seconds, so a fixed sleep is unreliable.
+        describe_acl_report = nil
+        describe_acl_handle = nil
+        30.times do
+          describe_acl_handle = admin.describe_acl(resource_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_ANY, resource_name: nil, resource_pattern_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_ANY, principal: nil, host: nil, operation: Rdkafka::Bindings::RD_KAFKA_ACL_OPERATION_ANY, permission_type: Rdkafka::Bindings::RD_KAFKA_ACL_PERMISSION_TYPE_ANY)
+          describe_acl_report = describe_acl_handle.wait(max_wait_timeout_ms: 15_000)
+          break if describe_acl_report.acls.length >= 2
+          sleep(0.5)
+        end
 
-        # describe_acl
-        describe_acl_handle = admin.describe_acl(resource_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_ANY, resource_name: nil, resource_pattern_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_ANY, principal: nil, host: nil, operation: Rdkafka::Bindings::RD_KAFKA_ACL_OPERATION_ANY, permission_type: Rdkafka::Bindings::RD_KAFKA_ACL_PERMISSION_TYPE_ANY)
-        describe_acl_report = describe_acl_handle.wait(max_wait_timeout_ms: 15_000)
         expect(describe_acl_handle[:response]).to eq(0)
         expect(describe_acl_report.acls.length).to eq(2)
 
@@ -892,20 +907,26 @@ RSpec.describe Rdkafka::Admin do
         expect(create_acl_report.rdkafka_response).to eq(0)
         expect(create_acl_report.rdkafka_response_string).to eq("")
 
-        # Since we create and immediately check, this is slow on loaded CIs, hence we wait
-        sleep(2)
+        # Poll describe_acl until both ACLs are visible. ACL propagation on
+        # slow (especially emulated aarch64) CI runners can take several
+        # seconds, so a fixed sleep is unreliable.
+        describe_acl_report = nil
+        describe_acl_handle = nil
+        30.times do
+          describe_acl_handle = admin.describe_acl(
+            resource_type: transactional_id_resource_type,
+            resource_name: nil,
+            resource_pattern_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_ANY,
+            principal: transactional_id_principal,
+            host: transactional_id_host,
+            operation: transactional_id_operation,
+            permission_type: transactional_id_permission_type
+          )
+          describe_acl_report = describe_acl_handle.wait(max_wait_timeout_ms: 15_000)
+          break if describe_acl_report.acls.length >= 2
+          sleep(0.5)
+        end
 
-        # Describe ACLs - filter by transactional_id resource type
-        describe_acl_handle = admin.describe_acl(
-          resource_type: transactional_id_resource_type,
-          resource_name: nil,
-          resource_pattern_type: Rdkafka::Bindings::RD_KAFKA_RESOURCE_PATTERN_ANY,
-          principal: transactional_id_principal,
-          host: transactional_id_host,
-          operation: transactional_id_operation,
-          permission_type: transactional_id_permission_type
-        )
-        describe_acl_report = describe_acl_handle.wait(max_wait_timeout_ms: 15_000)
         expect(describe_acl_handle[:response]).to eq(0)
         expect(describe_acl_report.acls.length).to eq(2)
       end

--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Rdkafka::Admin do
 
     before do
       admin.create_topic(topic_name, 2, 1).wait
-      sleep(1)
+      wait_for_topic(admin, topic_name)
     end
 
     context "when describing config of an existing topic" do
@@ -282,7 +282,7 @@ RSpec.describe Rdkafka::Admin do
 
     before do
       admin.create_topic(topic_name, 2, 1).wait
-      sleep(1)
+      wait_for_topic(admin, topic_name)
     end
 
     context "when altering one topic with one valid config via set" do
@@ -1071,7 +1071,7 @@ RSpec.describe Rdkafka::Admin do
     context "when topic has less then desired number of partitions" do
       before do
         admin.create_topic(topic_name, 1, 1).wait
-        sleep(1)
+        wait_for_topic(admin, topic_name)
       end
 
       it "expect to change number of partitions" do

--- a/spec/lib/rdkafka/statistics_filter_spec.rb
+++ b/spec/lib/rdkafka/statistics_filter_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Rdkafka::Config do
         consumer.subscribe("test")
         # Consumer needs time to join group, get partitions assigned, and start
         # fetching before topics appear in filtered stats
-        (15 * 20).times do
+        (30 * 20).times do
           break if stats.any? { |s| !s["topics"].empty? }
           consumer.poll(50)
         end
@@ -174,7 +174,7 @@ RSpec.describe Rdkafka::Config do
 
       after { consumer.close }
 
-      def poll_until(consumer, timeout: 15)
+      def poll_until(consumer, timeout: 30)
         (timeout * 20).times do
           break if yield
           consumer.poll(50)

--- a/spec/lib/rdkafka/statistics_filter_spec.rb
+++ b/spec/lib/rdkafka/statistics_filter_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe Rdkafka::Config do
         expect(broker).to have_key("tx")
         expect(broker).to have_key("rx")
       end
+
+      it "emits empty brokers.toppars for all brokers" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats(2)
+
+        stat = stats.reverse.find { |s| s["brokers"].any? { |_, b| b["toppars"] } }
+        expect(stat).not_to be_nil
+
+        stat["brokers"].each_value do |broker|
+          expect(broker).to have_key("toppars")
+          expect(broker["toppars"]).to be_empty
+        end
+      end
     end
 
     context "when set to false for a consumer" do
@@ -128,6 +141,27 @@ RSpec.describe Rdkafka::Config do
         expect(stat).not_to be_nil
         expect(stat["topics"]).to have_key("test")
       end
+
+      it "filters brokers.toppars to only actively fetching partitions" do
+        consumer.subscribe("test")
+        # Wait until partitions are assigned and the consumer is fetching
+        (30 * 20).times do
+          break if stats.any? { |s| !s["topics"].empty? }
+          consumer.poll(50)
+        end
+
+        stat = stats.reverse.find { |s| !s["topics"].empty? }
+        expect(stat).not_to be_nil
+
+        # Each broker entry should have a toppars key; entries present must
+        # belong to the subscribed topic (no unassigned partitions leaking).
+        stat["brokers"].each_value do |broker|
+          expect(broker).to have_key("toppars")
+          broker["toppars"].each_value do |tp|
+            expect(tp["topic"]).to eq("test")
+          end
+        end
+      end
     end
 
     context "when set to true (default behavior) for a producer" do
@@ -161,6 +195,19 @@ RSpec.describe Rdkafka::Config do
         expect(stat["brokers"]).not_to be_empty
         expect(stat["txmsgs"]).to be_a(Integer)
         expect(stat["rxmsgs"]).to be_a(Integer)
+      end
+
+      it "populates brokers.toppars for the produced topic" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats(3)
+
+        # At least one broker should report our test topic in its toppars map
+        has_test_toppar = stats.any? do |s|
+          s["brokers"].any? do |_, b|
+            (b["toppars"] || {}).any? { |_, tp| tp["topic"] == "test" }
+          end
+        end
+        expect(has_test_toppar).to be(true)
       end
     end
 
@@ -211,6 +258,25 @@ RSpec.describe Rdkafka::Config do
         expect(stat["brokers"]).not_to be_empty
         expect(stat["type"]).to eq("consumer")
         expect(stat["rxmsgs"]).to be_a(Integer)
+      end
+
+      it "populates brokers.toppars for the subscribed topic" do
+        consumer.subscribe("test")
+        poll_until(consumer) do
+          stats.any? do |s|
+            s["brokers"].any? do |_, b|
+              (b["toppars"] || {}).any? { |_, tp| tp["topic"] == "test" }
+            end
+          end
+        end
+
+        stat = stats.reverse.find do |s|
+          s["brokers"].any? do |_, b|
+            (b["toppars"] || {}).any? { |_, tp| tp["topic"] == "test" }
+          end
+        end
+
+        expect(stat).not_to be_nil
       end
     end
 

--- a/spec/lib/rdkafka/statistics_filter_spec.rb
+++ b/spec/lib/rdkafka/statistics_filter_spec.rb
@@ -1,215 +1,342 @@
 # frozen_string_literal: true
 
-RSpec.describe "statistics.unassigned.include config" do
-  let(:stats) { [] }
+RSpec.describe Rdkafka::Config do
+  describe "statistics.unassigned.include" do
+    let(:stats) { [] }
 
-  before do
-    Rdkafka::Config.statistics_callback = ->(published) { stats << published }
-  end
-
-  after do
-    Rdkafka::Config.statistics_callback = nil
-  end
-
-  def wait_for_stats(count = 1, timeout: 5)
-    (timeout * 20).times do
-      break if stats.size >= count
-      sleep 0.05
-    end
-  end
-
-  context "when set to false for a producer" do
-    let(:producer) do
-      rdkafka_producer_config(
-        "statistics.interval.ms": 100,
-        "statistics.unassigned.include": false
-      ).producer
+    before do
+      described_class.statistics_callback = ->(published) { stats << published }
     end
 
-    after { producer.close }
-
-    it "accepts the config without error" do
-      expect(producer).to be_a(Rdkafka::Producer)
+    after do
+      described_class.statistics_callback = nil
     end
 
-    it "still emits statistics with root-level keys" do
-      producer.produce(topic: "test", payload: "test").wait
-      wait_for_stats
-
-      stat = stats.last
-      expect(stat).to have_key("name")
-      expect(stat).to have_key("type")
-      expect(stat).to have_key("ts")
-      expect(stat).to have_key("brokers")
-      expect(stat).to have_key("topics")
-      expect(stat["type"]).to eq("producer")
-    end
-
-    it "emits empty topics section" do
-      producer.produce(topic: "test", payload: "test").wait
-      wait_for_stats
-
-      expect(stats.last["topics"]).to be_empty
-    end
-
-    it "preserves root-level aggregate totals" do
-      producer.produce(topic: "test", payload: "test").wait
-      wait_for_stats(2)
-
-      stat = stats.last
-      expect(stat["txmsgs"]).to be_a(Integer)
-      expect(stat["rxmsgs"]).to be_a(Integer)
-    end
-
-    it "preserves broker statistics" do
-      producer.produce(topic: "test", payload: "test").wait
-      wait_for_stats
-
-      brokers = stats.last["brokers"]
-      expect(brokers).not_to be_empty
-      broker = brokers.values.first
-      expect(broker).to have_key("tx")
-      expect(broker).to have_key("rx")
-    end
-  end
-
-  context "when set to false for a consumer" do
-    let(:consumer) do
-      rdkafka_consumer_config(
-        "statistics.interval.ms": 100,
-        "statistics.unassigned.include": false
-      ).consumer
-    end
-
-    after { consumer.close }
-
-    def poll_until_stats(consumer, count = 1, timeout: 5)
+    def wait_for_stats(count = 1, timeout: 5)
       (timeout * 20).times do
         break if stats.size >= count
-        consumer.poll(50)
+        sleep 0.05
       end
     end
 
-    it "accepts the config without error" do
-      expect(consumer).to be_a(Rdkafka::Consumer)
-    end
-
-    it "still emits statistics with root-level keys" do
-      consumer.subscribe("test")
-      poll_until_stats(consumer)
-
-      stat = stats.last
-      expect(stat).to have_key("name")
-      expect(stat).to have_key("type")
-      expect(stat).to have_key("brokers")
-      expect(stat["type"]).to eq("consumer")
-    end
-
-    it "preserves consumer group statistics" do
-      consumer.subscribe("test")
-      poll_until_stats(consumer, 2)
-
-      stat = stats.select { |s| s["cgrp"] }.last
-      expect(stat).not_to be_nil
-      expect(stat["cgrp"]).to have_key("state")
-    end
-
-    it "preserves topic data for consumers" do
-      consumer.subscribe("test")
-      # Consumer needs time to join group, get partitions assigned, and start
-      # fetching before topics appear in filtered stats
-      (15 * 20).times do
-        break if stats.any? { |s| !s["topics"].empty? }
-        consumer.poll(50)
+    context "when set to false for a producer" do
+      let(:producer) do
+        rdkafka_producer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": false
+        ).producer
       end
 
-      stat = stats.select { |s| !s["topics"].empty? }.last
-      expect(stat).not_to be_nil
-      expect(stat["topics"]).to have_key("test")
-    end
-  end
+      after { producer.close }
 
-  context "when set to true (default behavior) for a producer" do
-    let(:producer) do
-      rdkafka_producer_config(
-        "statistics.interval.ms": 100,
-        "statistics.unassigned.include": true
-      ).producer
-    end
+      it "accepts the config without error" do
+        expect(producer).to be_a(Rdkafka::Producer)
+      end
 
-    after { producer.close }
+      it "still emits statistics with root-level keys" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats
 
-    it "emits topics with partitions" do
-      producer.produce(topic: "test", payload: "test").wait
-      wait_for_stats(2)
+        stat = stats.last
+        expect(stat).to have_key("name")
+        expect(stat).to have_key("type")
+        expect(stat).to have_key("ts")
+        expect(stat).to have_key("brokers")
+        expect(stat).to have_key("topics")
+        expect(stat["type"]).to eq("producer")
+      end
 
-      stat = stats.select { |s| !s["topics"].empty? }.last
-      expect(stat).not_to be_nil
-      expect(stat["topics"]).to have_key("test")
-      expect(stat["topics"]["test"]["partitions"]).not_to be_empty
-    end
+      it "emits empty topics section" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats
 
-    it "preserves root-level keys and broker data" do
-      producer.produce(topic: "test", payload: "test").wait
-      wait_for_stats(2)
+        expect(stats.last["topics"]).to be_empty
+      end
 
-      stat = stats.last
-      expect(stat).to have_key("name")
-      expect(stat).to have_key("ts")
-      expect(stat).to have_key("brokers")
-      expect(stat["brokers"]).not_to be_empty
-      expect(stat["txmsgs"]).to be_a(Integer)
-      expect(stat["rxmsgs"]).to be_a(Integer)
-    end
-  end
+      it "preserves root-level aggregate totals" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats(2)
 
-  context "when set to true (default behavior) for a consumer" do
-    let(:consumer) do
-      rdkafka_consumer_config(
-        "statistics.interval.ms": 100,
-        "statistics.unassigned.include": true
-      ).consumer
-    end
+        stat = stats.last
+        expect(stat["txmsgs"]).to be_a(Integer)
+        expect(stat["rxmsgs"]).to be_a(Integer)
+      end
 
-    after { consumer.close }
+      it "preserves broker statistics" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats
 
-    def poll_until(consumer, timeout: 15)
-      (timeout * 20).times do
-        break if yield
-        consumer.poll(50)
+        brokers = stats.last["brokers"]
+        expect(brokers).not_to be_empty
+        broker = brokers.values.first
+        expect(broker).to have_key("tx")
+        expect(broker).to have_key("rx")
       end
     end
 
-    it "emits topics with partitions" do
-      consumer.subscribe("test")
-      poll_until(consumer) { stats.any? { |s| !s["topics"].empty? } }
+    context "when set to false for a consumer" do
+      let(:consumer) do
+        rdkafka_consumer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": false
+        ).consumer
+      end
 
-      stat = stats.select { |s| !s["topics"].empty? }.last
-      expect(stat).not_to be_nil
-      expect(stat["topics"]).to have_key("test")
-      expect(stat["topics"]["test"]["partitions"]).not_to be_empty
+      after { consumer.close }
+
+      def poll_until_stats(consumer, count = 1, timeout: 5)
+        (timeout * 20).times do
+          break if stats.size >= count
+          consumer.poll(50)
+        end
+      end
+
+      it "accepts the config without error" do
+        expect(consumer).to be_a(Rdkafka::Consumer)
+      end
+
+      it "still emits statistics with root-level keys" do
+        consumer.subscribe("test")
+        poll_until_stats(consumer)
+
+        stat = stats.last
+        expect(stat).to have_key("name")
+        expect(stat).to have_key("type")
+        expect(stat).to have_key("brokers")
+        expect(stat["type"]).to eq("consumer")
+      end
+
+      it "preserves consumer group statistics" do
+        consumer.subscribe("test")
+        poll_until_stats(consumer, 2)
+
+        stat = stats.reverse.find { |s| s["cgrp"] }
+        expect(stat).not_to be_nil
+        expect(stat["cgrp"]).to have_key("state")
+      end
+
+      it "preserves topic data for consumers" do
+        consumer.subscribe("test")
+        # Consumer needs time to join group, get partitions assigned, and start
+        # fetching before topics appear in filtered stats
+        (15 * 20).times do
+          break if stats.any? { |s| !s["topics"].empty? }
+          consumer.poll(50)
+        end
+
+        stat = stats.reverse.find { |s| !s["topics"].empty? }
+        expect(stat).not_to be_nil
+        expect(stat["topics"]).to have_key("test")
+      end
     end
 
-    it "preserves consumer group statistics" do
-      consumer.subscribe("test")
-      poll_until(consumer) { stats.any? { |s| s["cgrp"] } }
+    context "when set to true (default behavior) for a producer" do
+      let(:producer) do
+        rdkafka_producer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": true
+        ).producer
+      end
 
-      stat = stats.select { |s| s["cgrp"] }.last
-      expect(stat).not_to be_nil
-      expect(stat["cgrp"]).to have_key("state")
+      after { producer.close }
+
+      it "emits topics with partitions" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats(2)
+
+        stat = stats.reverse.find { |s| !s["topics"].empty? }
+        expect(stat).not_to be_nil
+        expect(stat["topics"]).to have_key("test")
+        expect(stat["topics"]["test"]["partitions"]).not_to be_empty
+      end
+
+      it "preserves root-level keys and broker data" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats(2)
+
+        stat = stats.last
+        expect(stat).to have_key("name")
+        expect(stat).to have_key("ts")
+        expect(stat).to have_key("brokers")
+        expect(stat["brokers"]).not_to be_empty
+        expect(stat["txmsgs"]).to be_a(Integer)
+        expect(stat["rxmsgs"]).to be_a(Integer)
+      end
     end
 
-    it "preserves root-level keys and broker data" do
-      consumer.subscribe("test")
-      poll_until(consumer) { stats.size >= 2 }
+    context "when set to true (default behavior) for a consumer" do
+      let(:consumer) do
+        rdkafka_consumer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": true
+        ).consumer
+      end
 
-      stat = stats.last
-      expect(stat).to have_key("name")
-      expect(stat).to have_key("type")
-      expect(stat).to have_key("brokers")
-      expect(stat["brokers"]).not_to be_empty
-      expect(stat["type"]).to eq("consumer")
-      expect(stat["rxmsgs"]).to be_a(Integer)
+      after { consumer.close }
+
+      def poll_until(consumer, timeout: 15)
+        (timeout * 20).times do
+          break if yield
+          consumer.poll(50)
+        end
+      end
+
+      it "emits topics with partitions" do
+        consumer.subscribe("test")
+        poll_until(consumer) { stats.any? { |s| !s["topics"].empty? } }
+
+        stat = stats.reverse.find { |s| !s["topics"].empty? }
+        expect(stat).not_to be_nil
+        expect(stat["topics"]).to have_key("test")
+        expect(stat["topics"]["test"]["partitions"]).not_to be_empty
+      end
+
+      it "preserves consumer group statistics" do
+        consumer.subscribe("test")
+        poll_until(consumer) { stats.any? { |s| s["cgrp"] } }
+
+        stat = stats.reverse.find { |s| s["cgrp"] }
+        expect(stat).not_to be_nil
+        expect(stat["cgrp"]).to have_key("state")
+      end
+
+      it "preserves root-level keys and broker data" do
+        consumer.subscribe("test")
+        poll_until(consumer) { stats.size >= 2 }
+
+        stat = stats.last
+        expect(stat).to have_key("name")
+        expect(stat).to have_key("type")
+        expect(stat).to have_key("brokers")
+        expect(stat["brokers"]).not_to be_empty
+        expect(stat["type"]).to eq("consumer")
+        expect(stat["rxmsgs"]).to be_a(Integer)
+      end
+    end
+
+    context "when config is omitted (default behavior)" do
+      let(:producer) do
+        rdkafka_producer_config("statistics.interval.ms": 100).producer
+      end
+
+      after { producer.close }
+
+      it "includes all topics and partitions by default" do
+        producer.produce(topic: "test", payload: "test").wait
+        wait_for_stats(2)
+
+        stat = stats.reverse.find { |s| !s["topics"].empty? }
+        expect(stat).not_to be_nil
+        expect(stat["topics"]).to have_key("test")
+        expect(stat["topics"]["test"]["partitions"]).not_to be_empty
+      end
+    end
+
+    context "when comparing JSON size with many partitions" do
+      let(:big_topic) { "stats-filter-big-#{SecureRandom.hex(6)}" }
+      let(:admin) { rdkafka_config.admin }
+
+      before do
+        admin.create_topic(big_topic, 1_000, 1).wait(max_wait_timeout_ms: 15_000)
+        wait_for_topic(admin, big_topic)
+      end
+
+      after do
+        begin
+          admin.delete_topic(big_topic).wait(max_wait_timeout_ms: 15_000)
+        rescue Rdkafka::RdkafkaError
+          nil
+        end
+
+        admin.close
+      end
+
+      it "produces significantly smaller statistics JSON for producers" do
+        filtered_stats = []
+        unfiltered_stats = []
+
+        described_class.statistics_callback = ->(published) { filtered_stats << published }
+
+        filtered_producer = rdkafka_producer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": false
+        ).producer
+        filtered_producer.produce(topic: big_topic, payload: "test").wait
+
+        wait = ->(target) {
+          (10 * 20).times do
+            break if target.size >= 2
+            sleep 0.05
+          end
+        }
+
+        wait.call(filtered_stats)
+        filtered_producer.close
+
+        described_class.statistics_callback = ->(published) { unfiltered_stats << published }
+
+        unfiltered_producer = rdkafka_producer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": true
+        ).producer
+        unfiltered_producer.produce(topic: big_topic, payload: "test").wait
+        wait.call(unfiltered_stats)
+        unfiltered_producer.close
+
+        filtered_json = JSON.generate(filtered_stats.last)
+        unfiltered_json = JSON.generate(unfiltered_stats.last)
+
+        expect(filtered_json.bytesize).to be < (unfiltered_json.bytesize / 2)
+      end
+
+      it "produces significantly smaller statistics JSON for consumers" do
+        filtered_stats = []
+        unfiltered_stats = []
+
+        poll_until = ->(consumer, target, &condition) {
+          (30 * 20).times do
+            break if condition.call(target)
+            begin
+              consumer.poll(50)
+            rescue Rdkafka::RdkafkaError
+              nil
+            end
+          end
+        }
+
+        # Unfiltered first so we can wait for topic metadata to appear
+        described_class.statistics_callback = ->(published) { unfiltered_stats << published }
+
+        unfiltered_consumer = rdkafka_consumer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": true
+        ).consumer
+        unfiltered_consumer.subscribe(big_topic)
+        has_partitions = ->(s) {
+          s.any? { |stat| (stat["topics"][big_topic] || {}).fetch("partitions", {}).size > 100 }
+        }
+        poll_until.call(unfiltered_consumer, unfiltered_stats, &has_partitions)
+        unfiltered_consumer.close
+
+        described_class.statistics_callback = ->(published) { filtered_stats << published }
+
+        filtered_consumer = rdkafka_consumer_config(
+          "statistics.interval.ms": 100,
+          "statistics.unassigned.include": false
+        ).consumer
+        filtered_consumer.subscribe(big_topic)
+        enough_stats = ->(s) { s.size >= 2 }
+        poll_until.call(filtered_consumer, filtered_stats, &enough_stats)
+        filtered_consumer.close
+
+        filtered_json = JSON.generate(filtered_stats.last)
+        unfiltered_stat = unfiltered_stats.reverse.find do |s|
+          (s["topics"][big_topic] || {}).fetch("partitions", {}).size > 100
+        end
+        unfiltered_json = JSON.generate(unfiltered_stat)
+
+        expect(filtered_json.bytesize).to be < (unfiltered_json.bytesize / 2)
+      end
     end
   end
 end

--- a/spec/lib/rdkafka/statistics_filter_spec.rb
+++ b/spec/lib/rdkafka/statistics_filter_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+RSpec.describe "statistics.unassigned.include config" do
+  let(:stats) { [] }
+
+  before do
+    Rdkafka::Config.statistics_callback = ->(published) { stats << published }
+  end
+
+  after do
+    Rdkafka::Config.statistics_callback = nil
+  end
+
+  def wait_for_stats(count = 1, timeout: 5)
+    (timeout * 20).times do
+      break if stats.size >= count
+      sleep 0.05
+    end
+  end
+
+  context "when set to false for a producer" do
+    let(:producer) do
+      rdkafka_producer_config(
+        "statistics.interval.ms": 100,
+        "statistics.unassigned.include": false
+      ).producer
+    end
+
+    after { producer.close }
+
+    it "accepts the config without error" do
+      expect(producer).to be_a(Rdkafka::Producer)
+    end
+
+    it "still emits statistics with root-level keys" do
+      producer.produce(topic: "test", payload: "test").wait
+      wait_for_stats
+
+      stat = stats.last
+      expect(stat).to have_key("name")
+      expect(stat).to have_key("type")
+      expect(stat).to have_key("ts")
+      expect(stat).to have_key("brokers")
+      expect(stat).to have_key("topics")
+      expect(stat["type"]).to eq("producer")
+    end
+
+    it "emits empty topics section" do
+      producer.produce(topic: "test", payload: "test").wait
+      wait_for_stats
+
+      expect(stats.last["topics"]).to be_empty
+    end
+
+    it "preserves root-level aggregate totals" do
+      producer.produce(topic: "test", payload: "test").wait
+      wait_for_stats(2)
+
+      stat = stats.last
+      expect(stat["txmsgs"]).to be_a(Integer)
+      expect(stat["rxmsgs"]).to be_a(Integer)
+    end
+
+    it "preserves broker statistics" do
+      producer.produce(topic: "test", payload: "test").wait
+      wait_for_stats
+
+      brokers = stats.last["brokers"]
+      expect(brokers).not_to be_empty
+      broker = brokers.values.first
+      expect(broker).to have_key("tx")
+      expect(broker).to have_key("rx")
+    end
+  end
+
+  context "when set to false for a consumer" do
+    let(:consumer) do
+      rdkafka_consumer_config(
+        "statistics.interval.ms": 100,
+        "statistics.unassigned.include": false
+      ).consumer
+    end
+
+    after { consumer.close }
+
+    def poll_until_stats(consumer, count = 1, timeout: 5)
+      (timeout * 20).times do
+        break if stats.size >= count
+        consumer.poll(50)
+      end
+    end
+
+    it "accepts the config without error" do
+      expect(consumer).to be_a(Rdkafka::Consumer)
+    end
+
+    it "still emits statistics with root-level keys" do
+      consumer.subscribe("test")
+      poll_until_stats(consumer)
+
+      stat = stats.last
+      expect(stat).to have_key("name")
+      expect(stat).to have_key("type")
+      expect(stat).to have_key("brokers")
+      expect(stat["type"]).to eq("consumer")
+    end
+
+    it "preserves consumer group statistics" do
+      consumer.subscribe("test")
+      poll_until_stats(consumer, 2)
+
+      stat = stats.select { |s| s["cgrp"] }.last
+      expect(stat).not_to be_nil
+      expect(stat["cgrp"]).to have_key("state")
+    end
+
+    it "preserves topic data for consumers" do
+      consumer.subscribe("test")
+      # Consumer needs time to join group, get partitions assigned, and start
+      # fetching before topics appear in filtered stats
+      (15 * 20).times do
+        break if stats.any? { |s| !s["topics"].empty? }
+        consumer.poll(50)
+      end
+
+      stat = stats.select { |s| !s["topics"].empty? }.last
+      expect(stat).not_to be_nil
+      expect(stat["topics"]).to have_key("test")
+    end
+  end
+
+  context "when set to true (default behavior) for a producer" do
+    let(:producer) do
+      rdkafka_producer_config(
+        "statistics.interval.ms": 100,
+        "statistics.unassigned.include": true
+      ).producer
+    end
+
+    after { producer.close }
+
+    it "emits topics with partitions" do
+      producer.produce(topic: "test", payload: "test").wait
+      wait_for_stats(2)
+
+      stat = stats.select { |s| !s["topics"].empty? }.last
+      expect(stat).not_to be_nil
+      expect(stat["topics"]).to have_key("test")
+      expect(stat["topics"]["test"]["partitions"]).not_to be_empty
+    end
+
+    it "preserves root-level keys and broker data" do
+      producer.produce(topic: "test", payload: "test").wait
+      wait_for_stats(2)
+
+      stat = stats.last
+      expect(stat).to have_key("name")
+      expect(stat).to have_key("ts")
+      expect(stat).to have_key("brokers")
+      expect(stat["brokers"]).not_to be_empty
+      expect(stat["txmsgs"]).to be_a(Integer)
+      expect(stat["rxmsgs"]).to be_a(Integer)
+    end
+  end
+
+  context "when set to true (default behavior) for a consumer" do
+    let(:consumer) do
+      rdkafka_consumer_config(
+        "statistics.interval.ms": 100,
+        "statistics.unassigned.include": true
+      ).consumer
+    end
+
+    after { consumer.close }
+
+    def poll_until(consumer, timeout: 15)
+      (timeout * 20).times do
+        break if yield
+        consumer.poll(50)
+      end
+    end
+
+    it "emits topics with partitions" do
+      consumer.subscribe("test")
+      poll_until(consumer) { stats.any? { |s| !s["topics"].empty? } }
+
+      stat = stats.select { |s| !s["topics"].empty? }.last
+      expect(stat).not_to be_nil
+      expect(stat["topics"]).to have_key("test")
+      expect(stat["topics"]["test"]["partitions"]).not_to be_empty
+    end
+
+    it "preserves consumer group statistics" do
+      consumer.subscribe("test")
+      poll_until(consumer) { stats.any? { |s| s["cgrp"] } }
+
+      stat = stats.select { |s| s["cgrp"] }.last
+      expect(stat).not_to be_nil
+      expect(stat["cgrp"]).to have_key("state")
+    end
+
+    it "preserves root-level keys and broker data" do
+      consumer.subscribe("test")
+      poll_until(consumer) { stats.size >= 2 }
+
+      stat = stats.last
+      expect(stat).to have_key("name")
+      expect(stat).to have_key("type")
+      expect(stat).to have_key("brokers")
+      expect(stat["brokers"]).not_to be_empty
+      expect(stat["type"]).to eq("consumer")
+      expect(stat["rxmsgs"]).to be_a(Integer)
+    end
+  end
+end

--- a/spec/lib/rdkafka/statistics_filter_spec.rb
+++ b/spec/lib/rdkafka/statistics_filter_spec.rb
@@ -242,16 +242,22 @@ RSpec.describe Rdkafka::Config do
       end
 
       after do
-        begin
-          admin.delete_topic(big_topic).wait(max_wait_timeout_ms: 15_000)
-        rescue Rdkafka::RdkafkaError
-          nil
+        unless admin.closed?
+          begin
+            admin.delete_topic(big_topic).wait(max_wait_timeout_ms: 15_000)
+          rescue Rdkafka::RdkafkaError
+            nil
+          end
         end
 
         admin.close
       end
 
       it "produces significantly smaller statistics JSON for producers" do
+        # Close the admin to prevent its unfiltered stats from leaking
+        # into our collection via the global callback
+        admin.close
+
         filtered_stats = []
         unfiltered_stats = []
 
@@ -290,6 +296,10 @@ RSpec.describe Rdkafka::Config do
       end
 
       it "produces significantly smaller statistics JSON for consumers" do
+        # Close the admin to prevent its unfiltered stats from leaking
+        # into our collection via the global callback
+        admin.close
+
         filtered_stats = []
         unfiltered_stats = []
 


### PR DESCRIPTION
Patch librdkafka to add a new boolean config property `statistics.unassigned.include` (default: true) that filters unassigned partition data from the statistics JSON output.

When set to false:
- Producers emit an empty topics section
- Consumers exclude partitions whose fetch state has not started

Partition counters still contribute to root-level aggregate totals in both cases. This significantly reduces statistics JSON size on large clusters with many unassigned partitions.