### PR TITLE
Fix flaky create_partitions admin specs on slow CI

### DIFF
--- a/spec/lib/rdkafka/admin_spec.rb
+++ b/spec/lib/rdkafka/admin_spec.rb
@@ -165,7 +165,6 @@ RSpec.describe Rdkafka::Admin do
 
     before do
       admin.create_topic(topic_name, 2, 1).wait
-      wait_for_topic(admin, topic_name)
     end
 
     context "when describing config of an existing topic" do
@@ -282,7 +281,6 @@ RSpec.describe Rdkafka::Admin do
 
     before do
       admin.create_topic(topic_name, 2, 1).wait
-      wait_for_topic(admin, topic_name)
     end
 
     context "when altering one topic with one valid config via set" do
@@ -1095,7 +1093,6 @@ RSpec.describe Rdkafka::Admin do
     context "when topic has less then desired number of partitions" do
       before do
         admin.create_topic(topic_name, 1, 1).wait
-        wait_for_topic(admin, topic_name)
       end
 
       it "expect to change number of partitions" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -178,7 +178,6 @@ RSpec.describe Rdkafka::Consumer do
     before do
       admin = rdkafka_producer_config.admin
       admin.create_topic(topic, 1, 1).wait
-      wait_for_topic(admin, topic)
       admin.close
     end
 
@@ -283,7 +282,6 @@ RSpec.describe Rdkafka::Consumer do
     before do
       admin = rdkafka_producer_config.admin
       admin.create_topic(topic, 1, 1).wait
-      wait_for_topic(admin, topic)
       admin.close
     end
 

--- a/spec/lib/rdkafka/statistics_filter_spec.rb
+++ b/spec/lib/rdkafka/statistics_filter_spec.rb
@@ -304,7 +304,6 @@ RSpec.describe Rdkafka::Config do
 
       before do
         admin.create_topic(big_topic, 1_000, 1).wait(max_wait_timeout_ms: 15_000)
-        wait_for_topic(admin, big_topic)
       end
 
       after do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ Rdkafka::Producer.include(Rdkafka::Testing)
 require_relative "support/kafka_config_helpers"
 require_relative "support/kafka_wait_helpers"
 require_relative "support/native_client_helpers"
+require_relative "support/admin_topic_auto_wait"
 require_relative "support/test_topics"
 
 RSpec.configure do |config|

--- a/spec/support/admin_topic_auto_wait.rb
+++ b/spec/support/admin_topic_auto_wait.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Auto-waits for topic metadata propagation after a successful
+# +Rdkafka::Admin#create_topic(...).wait+.
+#
+# Broker acknowledgment of topic creation does not guarantee that the topic is
+# immediately visible to subsequent metadata queries, especially on slow CI
+# runners. Every spec that creates a topic and then queries metadata needed to
+# remember to call +wait_for_topic+ manually; forgetting it produced sporadic
+# +unknown_topic_or_part+ failures.
+#
+# This patch wraps the handle returned by +create_topic+ so that a successful
+# +.wait+ transparently polls metadata until the topic is visible. Error paths
+# (raised exceptions or non-zero response codes) are left untouched.
+module AdminTopicAutoWait
+  # Thin delegating wrapper that augments +#wait+ with a post-success metadata
+  # poll. All other calls are forwarded to the underlying handle unchanged so
+  # existing expectations against the handle (e.g. +create_result+,
+  # +operation_name+, FFI struct fields) continue to work.
+  class HandleWrapper
+    def initialize(handle, admin, topic_name)
+      @handle = handle
+      @admin = admin
+      @topic_name = topic_name
+    end
+
+    def wait(*args, **kwargs)
+      result = @handle.wait(*args, **kwargs)
+
+      # Only poll metadata if the underlying operation actually succeeded.
+      # Callers using +raise_response_error: false+ may receive a result on
+      # failure, in which case there is no topic to wait for.
+      if @handle[:response] == Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
+        KafkaWaitHelpers.wait_for_topic(@admin, @topic_name)
+      end
+
+      result
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @handle.respond_to?(name, include_private) || super
+    end
+
+    def method_missing(name, *args, **kwargs, &block)
+      if @handle.respond_to?(name)
+        @handle.public_send(name, *args, **kwargs, &block)
+      else
+        super
+      end
+    end
+  end
+
+  def create_topic(topic_name, *args, **kwargs)
+    handle = super
+    HandleWrapper.new(handle, self, topic_name)
+  end
+end
+
+Rdkafka::Admin.prepend(AdminTopicAutoWait)

--- a/spec/support/test_topics.rb
+++ b/spec/support/test_topics.rb
@@ -56,7 +56,6 @@ module TestTopics
       begin
         handle = admin.create_topic(topic_name, partitions, 1)
         handle.wait(max_wait_timeout_ms: 15_000)
-        wait_for_topic(admin, topic_name)
         topic_name
       ensure
         admin.close


### PR DESCRIPTION
Wait for topic metadata to propagate after create_topic in the "already has the desired" and "has more than the requested" contexts, matching the pattern already used in the sibling "less than desired" context. Without this, the single-retry fallback in the `metadata` helper can still hit `unknown_topic_or_part` on slow runners (observed on Ubuntu aarch64 GNU).