### PR TITLE
Enable lockFileMaintenance in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -90,5 +90,8 @@
   ],
   "labels": [
     "dependencies"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This ensures Renovate periodically updates lockfile-only dependencies (transitive deps and those without version pins) that would otherwise never get updated.