### PR TITLE
Fix poll_nb/poll_nb_each/poll_batch/poll_batch_nb losing error contex…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Rdkafka Changelog
 
-## 0.28.0 (Unreleased)
+## 0.27.1 (Unreleased)
 - [Fix] `poll_nb`, `poll_nb_each`, `poll_batch`, and `poll_batch_nb` now raise `RdkafkaError` with `details` populated (`{topic:, partition:, offset:}`) when a message contains an error (e.g. `:partition_eof`). Previously these methods raised via `RdkafkaError.new(code)`, discarding the native message struct context. They now use `RdkafkaError.validate!(native_message, client_ptr: inner)`, consistent with `poll`.
 
 ## 0.27.0 (2026-05-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.28.0 (Unreleased)
+- [Fix] `poll_nb`, `poll_nb_each`, `poll_batch`, and `poll_batch_nb` now raise `RdkafkaError` with `details` populated (`{topic:, partition:, offset:}`) when a message contains an error (e.g. `:partition_eof`). Previously these methods raised via `RdkafkaError.new(code)`, discarding the native message struct context. They now use `RdkafkaError.validate!(native_message, client_ptr: inner)`, consistent with `poll`.
+
 ## 0.27.0 (2026-05-08)
 - [Feature] Add `Consumer#poll_batch(timeout_ms, max_items:)` and `Consumer#poll_batch_nb(timeout_ms, max_items:)` for batch message polling via `rd_kafka_consume_batch_queue` (from upstream).
 - [Enhancement] Bump librdkafka to `2.14.1`.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -163,7 +163,7 @@ module Rdkafka
             native_message = Rdkafka::Bindings::Message.new(message_ptr)
 
             if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-              raise Rdkafka::RdkafkaError.new(native_message[:err])
+              Rdkafka::RdkafkaError.validate!(native_message, client_ptr: inner)
             end
 
             result = yield Consumer::Message.new(native_message)
@@ -736,7 +736,9 @@ module Rdkafka
         native_message = Rdkafka::Bindings::Message.new(message_ptr)
         # Raise error if needed
         if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-          raise Rdkafka::RdkafkaError.new(native_message[:err])
+          @native_kafka.with_inner do |inner|
+            Rdkafka::RdkafkaError.validate!(native_message, client_ptr: inner)
+          end
         end
         # Create a message to pass out
         Rdkafka::Consumer::Message.new(native_message)
@@ -834,7 +836,9 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            raise Rdkafka::RdkafkaError.new(native_message[:err])
+            @native_kafka.with_inner do |inner|
+              Rdkafka::RdkafkaError.validate!(native_message, client_ptr: inner)
+            end
           end
 
           messages << Rdkafka::Consumer::Message.new(native_message)
@@ -896,7 +900,9 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            raise Rdkafka::RdkafkaError.new(native_message[:err])
+            @native_kafka.with_inner do |inner|
+              Rdkafka::RdkafkaError.validate!(native_message, client_ptr: inner)
+            end
           end
 
           messages << Rdkafka::Consumer::Message.new(native_message)

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -2,7 +2,7 @@
 
 module Rdkafka
   # Current rdkafka-ruby gem version
-  VERSION = "0.27.0"
+  VERSION = "0.27.1"
   # Target librdkafka version to be used
   LIBRDKAFKA_VERSION = "2.14.1"
   # SHA256 hash of the librdkafka source tarball for verification

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -954,13 +954,18 @@ RSpec.describe Rdkafka::Consumer do
     it "raises an error when polling fails" do
       message = Rdkafka::Bindings::Message.new.tap do |message|
         message[:err] = 20
+        message[:partition] = 2
+        message[:offset] = 55
       end
       message_pointer = message.to_ptr
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consumer_poll_nb).and_return(message_pointer)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(message_pointer)
       expect {
         consumer.poll_nb
-      }.to raise_error Rdkafka::RdkafkaError
+      }.to raise_error(Rdkafka::RdkafkaError) do |error|
+        expect(error.details[:partition]).to eq(2)
+        expect(error.details[:offset]).to eq(55)
+      end
     end
 
     context "when consumer is closed" do
@@ -1427,30 +1432,51 @@ RSpec.describe Rdkafka::Consumer do
   describe "when reaching eof on a topic and eof reporting enabled" do
     let(:consumer) { rdkafka_consumer_config("enable.partition.eof": true).consumer }
 
-    it "returns proper details" do
-      (0..2).each do |i|
-        producer.produce(
-          topic: topic,
-          key: "key lag #{i}",
-          partition: i
-        ).wait
-      end
-
-      # Consume to the end
+    def collect_eof(consumer, poll_method, **kwargs)
       consumer.subscribe(topic)
       eof_error = nil
+      deadline = Time.now + 30
 
       loop do
-        consumer.poll(100)
+        break if Time.now > deadline
+
+        if poll_method == :poll_nb_each
+          consumer.poll_nb_each { |_| }
+          sleep 0.05
+        else
+          consumer.public_send(poll_method, **kwargs)
+        end
       rescue Rdkafka::RdkafkaError => error
         if error.is_partition_eof?
           eof_error = error
+          break
         end
-        break if eof_error
       end
 
-      expect(eof_error.code).to eq(:partition_eof)
+      eof_error
     end
+
+    before do
+      producer.produce(topic: topic, key: "key eof", partition: 0).wait
+    end
+
+    shared_examples "raises partition_eof with details" do |method, **kwargs|
+      it "raises :partition_eof with topic/partition/offset details via ##{method}" do
+        error = collect_eof(consumer, method, **kwargs)
+
+        expect(error).not_to be_nil
+        expect(error.code).to eq(:partition_eof)
+        expect(error.details[:topic]).to eq(topic)
+        expect(error.details[:partition]).to be_a(Integer)
+        expect(error.details[:offset]).to be_a(Integer)
+      end
+    end
+
+    include_examples "raises partition_eof with details", :poll, timeout_ms: 100
+    include_examples "raises partition_eof with details", :poll_nb, timeout_ms: 100
+    include_examples "raises partition_eof with details", :poll_nb_each
+    include_examples "raises partition_eof with details", :poll_batch, timeout_ms: 100, max_items: 10
+    include_examples "raises partition_eof with details", :poll_batch_nb, timeout_ms: 100, max_items: 10
   end
 
   describe "long running consumption" do
@@ -1671,6 +1697,8 @@ RSpec.describe Rdkafka::Consumer do
     it "raises an error when a message has an error" do
       message = Rdkafka::Bindings::Message.new.tap do |msg|
         msg[:err] = 20
+        msg[:partition] = 1
+        msg[:offset] = 42
       end
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
@@ -1684,7 +1712,10 @@ RSpec.describe Rdkafka::Consumer do
 
       expect {
         consumer.poll_batch(100, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError)
+      }.to raise_error(Rdkafka::RdkafkaError) do |error|
+        expect(error.details[:partition]).to eq(1)
+        expect(error.details[:offset]).to eq(42)
+      end
     end
 
     context "when consumer is closed" do
@@ -1747,6 +1778,8 @@ RSpec.describe Rdkafka::Consumer do
     it "raises an error when a message has an error" do
       message = Rdkafka::Bindings::Message.new.tap do |msg|
         msg[:err] = 20
+        msg[:partition] = 3
+        msg[:offset] = 77
       end
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
@@ -1760,7 +1793,10 @@ RSpec.describe Rdkafka::Consumer do
 
       expect {
         consumer.poll_batch_nb(0, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError)
+      }.to raise_error(Rdkafka::RdkafkaError) do |error|
+        expect(error.details[:partition]).to eq(3)
+        expect(error.details[:offset]).to eq(77)
+      end
     end
 
     context "when consumer is closed" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -954,18 +954,13 @@ RSpec.describe Rdkafka::Consumer do
     it "raises an error when polling fails" do
       message = Rdkafka::Bindings::Message.new.tap do |message|
         message[:err] = 20
-        message[:partition] = 2
-        message[:offset] = 55
       end
       message_pointer = message.to_ptr
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consumer_poll_nb).and_return(message_pointer)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(message_pointer)
       expect {
         consumer.poll_nb
-      }.to raise_error(Rdkafka::RdkafkaError) do |error|
-        expect(error.details[:partition]).to eq(2)
-        expect(error.details[:offset]).to eq(55)
-      end
+      }.to raise_error Rdkafka::RdkafkaError
     end
 
     context "when consumer is closed" do
@@ -1432,20 +1427,14 @@ RSpec.describe Rdkafka::Consumer do
   describe "when reaching eof on a topic and eof reporting enabled" do
     let(:consumer) { rdkafka_consumer_config("enable.partition.eof": true).consumer }
 
-    def collect_eof(consumer, poll_method, **kwargs)
+    def collect_eof_error(consumer, &poll_block)
       consumer.subscribe(topic)
       eof_error = nil
       deadline = Time.now + 30
 
       loop do
         break if Time.now > deadline
-
-        if poll_method == :poll_nb_each
-          consumer.poll_nb_each { |_| }
-          sleep 0.05
-        else
-          consumer.public_send(poll_method, **kwargs)
-        end
+        poll_block.call
       rescue Rdkafka::RdkafkaError => error
         if error.is_partition_eof?
           eof_error = error
@@ -1456,27 +1445,45 @@ RSpec.describe Rdkafka::Consumer do
       eof_error
     end
 
+    def expect_eof_details(error, expected_topic)
+      expect(error).not_to be_nil
+      expect(error.code).to eq(:partition_eof)
+      expect(error.details[:topic]).to eq(expected_topic)
+      expect(error.details[:partition]).to be_a(Integer)
+      expect(error.details[:offset]).to be_a(Integer)
+    end
+
     before do
       producer.produce(topic: topic, key: "key eof", partition: 0).wait
     end
 
-    shared_examples "raises partition_eof with details" do |method, **kwargs|
-      it "raises :partition_eof with topic/partition/offset details via ##{method}" do
-        error = collect_eof(consumer, method, **kwargs)
-
-        expect(error).not_to be_nil
-        expect(error.code).to eq(:partition_eof)
-        expect(error.details[:topic]).to eq(topic)
-        expect(error.details[:partition]).to be_a(Integer)
-        expect(error.details[:offset]).to be_a(Integer)
-      end
+    it "raises :partition_eof with topic/partition/offset details via #poll" do
+      error = collect_eof_error(consumer) { consumer.poll(100) }
+      expect_eof_details(error, topic)
     end
 
-    include_examples "raises partition_eof with details", :poll, timeout_ms: 100
-    include_examples "raises partition_eof with details", :poll_nb, timeout_ms: 100
-    include_examples "raises partition_eof with details", :poll_nb_each
-    include_examples "raises partition_eof with details", :poll_batch, timeout_ms: 100, max_items: 10
-    include_examples "raises partition_eof with details", :poll_batch_nb, timeout_ms: 100, max_items: 10
+    it "raises :partition_eof with topic/partition/offset details via #poll_nb" do
+      error = collect_eof_error(consumer) { consumer.poll_nb(100) }
+      expect_eof_details(error, topic)
+    end
+
+    it "raises :partition_eof with topic/partition/offset details via #poll_nb_each" do
+      error = collect_eof_error(consumer) do
+        consumer.poll_nb_each { |_| }
+        sleep 0.05
+      end
+      expect_eof_details(error, topic)
+    end
+
+    it "raises :partition_eof with topic/partition/offset details via #poll_batch" do
+      error = collect_eof_error(consumer) { consumer.poll_batch(100, max_items: 10) }
+      expect_eof_details(error, topic)
+    end
+
+    it "raises :partition_eof with topic/partition/offset details via #poll_batch_nb" do
+      error = collect_eof_error(consumer) { consumer.poll_batch_nb(100, max_items: 10) }
+      expect_eof_details(error, topic)
+    end
   end
 
   describe "long running consumption" do
@@ -1697,8 +1704,6 @@ RSpec.describe Rdkafka::Consumer do
     it "raises an error when a message has an error" do
       message = Rdkafka::Bindings::Message.new.tap do |msg|
         msg[:err] = 20
-        msg[:partition] = 1
-        msg[:offset] = 42
       end
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
@@ -1712,10 +1717,7 @@ RSpec.describe Rdkafka::Consumer do
 
       expect {
         consumer.poll_batch(100, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError) do |error|
-        expect(error.details[:partition]).to eq(1)
-        expect(error.details[:offset]).to eq(42)
-      end
+      }.to raise_error(Rdkafka::RdkafkaError)
     end
 
     context "when consumer is closed" do
@@ -1778,8 +1780,6 @@ RSpec.describe Rdkafka::Consumer do
     it "raises an error when a message has an error" do
       message = Rdkafka::Bindings::Message.new.tap do |msg|
         msg[:err] = 20
-        msg[:partition] = 3
-        msg[:offset] = 77
       end
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
@@ -1793,10 +1793,7 @@ RSpec.describe Rdkafka::Consumer do
 
       expect {
         consumer.poll_batch_nb(0, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError) do |error|
-        expect(error.details[:partition]).to eq(3)
-        expect(error.details[:offset]).to eq(77)
-      end
+      }.to raise_error(Rdkafka::RdkafkaError)
     end
 
     context "when consumer is closed" do


### PR DESCRIPTION
…t in RdkafkaError#details

These four methods raised RdkafkaError.new(native_message[:err]), discarding the native message struct and leaving e.details as {} on every error. Change them to use RdkafkaError.validate!(native_message, client_ptr: inner), consistent with poll (which was already correct). This fixes the Karafka TopicNotFoundError crash where @buffer.eof(nil, nil) creates a nil-keyed entry when enable.partition.eof=true.