### PR TITLE
Fix poll_batch/poll_batch_nb silently discarding events after first e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rdkafka Changelog
 
 ## 0.27.2 (Unreleased)
-- [Feature] `poll_batch` and `poll_batch_nb` now accept an optional block for error handling.
+- [Fix] `poll_batch` and `poll_batch_nb` now accept an optional block to observe all error events in a batch before the first error is raised, preventing silent discard of subsequent error events.
 
 ## 0.27.1 (2026-05-14)
 - [Fix] `poll_nb`, `poll_nb_each`, `poll_batch`, and `poll_batch_nb` now raise `RdkafkaError` with `details` populated (`{topic:, partition:, offset:}`) when a message contains an error (e.g. `:partition_eof`). Previously these methods raised via `RdkafkaError.new(code)`, discarding the native message struct context. They now use `RdkafkaError.validate!(native_message, client_ptr: inner)`, consistent with `poll`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rdkafka Changelog
 
 ## 0.27.2 (Unreleased)
-- [Fix] `poll_batch` and `poll_batch_nb` now accept an optional block to observe all error events in a batch before the first error is raised, preventing silent discard of subsequent error events.
+- [Breaking] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
 
 ## 0.27.1 (2026-05-14)
 - [Fix] `poll_nb`, `poll_nb_each`, `poll_batch`, and `poll_batch_nb` now raise `RdkafkaError` with `details` populated (`{topic:, partition:, offset:}`) when a message contains an error (e.g. `:partition_eof`). Previously these methods raised via `RdkafkaError.new(code)`, discarding the native message struct context. They now use `RdkafkaError.validate!(native_message, client_ptr: inner)`, consistent with `poll`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rdkafka Changelog
 
 ## 0.27.2 (Unreleased)
-- [Breaking] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
+- [Enhancement] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
 
 ## 0.27.1 (2026-05-14)
 - [Fix] `poll_nb`, `poll_nb_each`, `poll_batch`, and `poll_batch_nb` now raise `RdkafkaError` with `details` populated (`{topic:, partition:, offset:}`) when a message contains an error (e.g. `:partition_eof`). Previously these methods raised via `RdkafkaError.new(code)`, discarding the native message struct context. They now use `RdkafkaError.validate!(native_message, client_ptr: inner)`, consistent with `poll`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## 0.27.2 (Unreleased)
+- [Feature] `poll_batch` and `poll_batch_nb` now accept an optional block for error handling.
+
 ## 0.27.1 (2026-05-14)
 - [Fix] `poll_nb`, `poll_nb_each`, `poll_batch`, and `poll_batch_nb` now raise `RdkafkaError` with `details` populated (`{topic:, partition:, offset:}`) when a message contains an error (e.g. `:partition_eof`). Previously these methods raised via `RdkafkaError.new(code)`, discarding the native message struct context. They now use `RdkafkaError.validate!(native_message, client_ptr: inner)`, consistent with `poll`.
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -1014,13 +1014,13 @@ module Rdkafka
     # @param native_message [Rdkafka::Bindings::Message] the errored native message
     # @return [RdkafkaError]
     def build_batch_error(native_message)
-      @native_kafka.with_inner do |inner|
-        err = Rdkafka::RdkafkaError.build(native_message)
-        if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
+      err = Rdkafka::RdkafkaError.build(native_message)
+      if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
+        @native_kafka.with_inner do |inner|
           Rdkafka::RdkafkaError.build_fatal(inner, fallback_error_code: err.rdkafka_response)
-        else
-          err
         end
+      else
+        err
       end
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -805,9 +805,12 @@ module Rdkafka
     # is yielded to the block instead of halting the loop immediately. This allows the
     # caller to observe *all* error events in the batch — for example, EOF signals from
     # multiple partitions that arrived simultaneously — rather than losing the ones that
-    # follow the first error. Processing continues after each yielded error, collecting
-    # subsequent normal messages. The first error encountered is still raised after the
+    # follow the first error. The first error encountered is still raised after the
     # full batch is processed and all native pointers are cleaned up.
+    #
+    # Note: even in block mode, normal messages from a batch that also contains errors are
+    # consumed and destroyed but are NOT returned to the caller — the method raises the
+    # first error regardless of whether any normal messages were processed.
     #
     # Without a block the behaviour is unchanged from before: the first error halts
     # processing and is raised (all remaining native pointers are still cleaned up by
@@ -816,7 +819,7 @@ module Rdkafka
     # @param timeout_ms [Integer] Timeout waiting for the first message (-1 for infinite)
     # @param max_items [Integer] Maximum number of messages to return per call
     # @yieldparam error [RdkafkaError] Each error event found in the batch
-    # @return [Array<Message>] Array of messages (empty if none available within timeout)
+    # @return [Array<Message>] Array of messages; empty when any error was encountered
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch(timeout_ms, max_items: 100)
@@ -850,18 +853,7 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            # Build the error before destroying the pointer so topic/partition/offset
-            # details can be read from the native struct. Preserve fatal-error detection
-            # by checking whether librdkafka flagged a fatal condition.
-            error = @native_kafka.with_inner do |inner|
-              err = Rdkafka::RdkafkaError.build(native_message)
-              if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
-                Rdkafka::RdkafkaError.build_fatal(inner, fallback_error_code: err.rdkafka_response)
-              else
-                err
-              end
-            end
-
+            error = build_batch_error(native_message)
             Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
             i += 1
 
@@ -902,12 +894,13 @@ module Rdkafka
     # Accepts an optional block with the same semantics as {#poll_batch}: when given,
     # errors are yielded rather than immediately raised, allowing all error events in
     # the batch to be observed. The first error is still raised after the batch is
-    # fully processed.
+    # fully processed. Normal messages from a batch that also contains errors are
+    # consumed and destroyed but not returned; see {#poll_batch} for details.
     #
     # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
     # @param max_items [Integer] Maximum number of messages to return per call
     # @yieldparam error [RdkafkaError] Each error event found in the batch
-    # @return [Array<Message>] Array of messages (empty if none available within timeout)
+    # @return [Array<Message>] Array of messages; empty when any error was encountered
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch_nb(timeout_ms = 0, max_items: 100)
@@ -941,15 +934,7 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            error = @native_kafka.with_inner do |inner|
-              err = Rdkafka::RdkafkaError.build(native_message)
-              if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
-                Rdkafka::RdkafkaError.build_fatal(inner, fallback_error_code: err.rdkafka_response)
-              else
-                err
-              end
-            end
-
+            error = build_batch_error(native_message)
             Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
             i += 1
 
@@ -1056,6 +1041,21 @@ module Rdkafka
     def consumer_queue
       @consumer_queue ||= @native_kafka.with_inner do |inner|
         Rdkafka::Bindings.rd_kafka_queue_get_consumer(inner)
+      end
+    end
+
+    # Builds an RdkafkaError from a native message, promoting to a fatal error when
+    # librdkafka flagged a fatal condition on the underlying client handle.
+    # @param native_message [Rdkafka::Bindings::Message] the errored native message
+    # @return [RdkafkaError]
+    def build_batch_error(native_message)
+      @native_kafka.with_inner do |inner|
+        err = Rdkafka::RdkafkaError.build(native_message)
+        if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
+          Rdkafka::RdkafkaError.build_fatal(inner, fallback_error_code: err.rdkafka_response)
+        else
+          err
+        end
       end
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -801,8 +801,21 @@ module Rdkafka
     # is available, librdkafka fills the buffer with whatever is immediately ready and
     # returns without further waiting.
     #
+    # When a block is given, every error encountered in the batch (e.g. `:partition_eof`)
+    # is yielded to the block instead of halting the loop immediately. This allows the
+    # caller to observe *all* error events in the batch — for example, EOF signals from
+    # multiple partitions that arrived simultaneously — rather than losing the ones that
+    # follow the first error. Processing continues after each yielded error, collecting
+    # subsequent normal messages. The first error encountered is still raised after the
+    # full batch is processed and all native pointers are cleaned up.
+    #
+    # Without a block the behaviour is unchanged from before: the first error halts
+    # processing and is raised (all remaining native pointers are still cleaned up by
+    # the ensure clause).
+    #
     # @param timeout_ms [Integer] Timeout waiting for the first message (-1 for infinite)
     # @param max_items [Integer] Maximum number of messages to return per call
+    # @yieldparam error [RdkafkaError] Each error event found in the batch
     # @return [Array<Message>] Array of messages (empty if none available within timeout)
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
@@ -824,6 +837,7 @@ module Rdkafka
       return messages if count <= 0
 
       i = 0
+      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -836,9 +850,28 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            @native_kafka.with_inner do |inner|
-              Rdkafka::RdkafkaError.validate!(native_message, client_ptr: inner)
+            # Build the error before destroying the pointer so topic/partition/offset
+            # details can be read from the native struct. Preserve fatal-error detection
+            # by checking whether librdkafka flagged a fatal condition.
+            error = @native_kafka.with_inner do |inner|
+              err = Rdkafka::RdkafkaError.build(native_message)
+              if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
+                Rdkafka::RdkafkaError.build_fatal(inner, fallback_error_code: err.rdkafka_response)
+              else
+                err
+              end
             end
+
+            Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
+            i += 1
+
+            if block_given?
+              yield error
+              first_error ||= error
+              next
+            end
+
+            raise error
           end
 
           messages << Rdkafka::Consumer::Message.new(native_message)
@@ -853,6 +886,7 @@ module Rdkafka
         end
       end
 
+      raise first_error if first_error
       messages
     end
 
@@ -865,8 +899,14 @@ module Rdkafka
     # @note Since the GVL is not released, a non-zero timeout_ms will block all Ruby
     #   threads/fibers for the duration. Use {#poll_batch} if you need a blocking wait.
     #
+    # Accepts an optional block with the same semantics as {#poll_batch}: when given,
+    # errors are yielded rather than immediately raised, allowing all error events in
+    # the batch to be observed. The first error is still raised after the batch is
+    # fully processed.
+    #
     # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
     # @param max_items [Integer] Maximum number of messages to return per call
+    # @yieldparam error [RdkafkaError] Each error event found in the batch
     # @return [Array<Message>] Array of messages (empty if none available within timeout)
     # @raise [RdkafkaError] When a consumed message contains an error
     # @raise [ClosedConsumerError] When called on a closed consumer
@@ -888,6 +928,7 @@ module Rdkafka
       return messages if count <= 0
 
       i = 0
+      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -900,9 +941,25 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            @native_kafka.with_inner do |inner|
-              Rdkafka::RdkafkaError.validate!(native_message, client_ptr: inner)
+            error = @native_kafka.with_inner do |inner|
+              err = Rdkafka::RdkafkaError.build(native_message)
+              if err && err.rdkafka_response == Rdkafka::Bindings::RD_KAFKA_RESP_ERR__FATAL
+                Rdkafka::RdkafkaError.build_fatal(inner, fallback_error_code: err.rdkafka_response)
+              else
+                err
+              end
             end
+
+            Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
+            i += 1
+
+            if block_given?
+              yield error
+              first_error ||= error
+              next
+            end
+
+            raise error
           end
 
           messages << Rdkafka::Consumer::Message.new(native_message)
@@ -917,6 +974,7 @@ module Rdkafka
         end
       end
 
+      raise first_error if first_error
       messages
     end
 

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -801,32 +801,21 @@ module Rdkafka
     # is available, librdkafka fills the buffer with whatever is immediately ready and
     # returns without further waiting.
     #
-    # When a block is given, every error encountered in the batch (e.g. `:partition_eof`)
-    # is yielded to the block instead of halting the loop immediately. This allows the
-    # caller to observe *all* error events in the batch — for example, EOF signals from
-    # multiple partitions that arrived simultaneously — rather than losing the ones that
-    # follow the first error. The first error encountered is still raised after the
-    # full batch is processed and all native pointers are cleaned up.
-    #
-    # Note: even in block mode, normal messages from a batch that also contains errors are
-    # consumed and destroyed but are NOT returned to the caller — the method raises the
-    # first error regardless of whether any normal messages were processed.
-    #
-    # Without a block the behaviour is unchanged from before: the first error halts
-    # processing and is raised (all remaining native pointers are still cleaned up by
-    # the ensure clause).
+    # Error events (e.g. `:partition_eof`) are returned inline as {RdkafkaError} objects
+    # rather than raised, so callers receive the complete batch — both messages and errors —
+    # and can decide how to handle each. This is particularly useful when multiple partitions
+    # signal EOF simultaneously: all signals appear in the returned array rather than only
+    # the first one being raised and the rest silently discarded.
     #
     # @param timeout_ms [Integer] Timeout waiting for the first message (-1 for infinite)
     # @param max_items [Integer] Maximum number of messages to return per call
-    # @yieldparam error [RdkafkaError] Each error event found in the batch
-    # @return [Array<Message>] Array of messages; empty when any error was encountered
-    # @raise [RdkafkaError] When a consumed message contains an error
+    # @return [Array<Message, RdkafkaError>] Batch of messages and/or error events in arrival order
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch(timeout_ms, max_items: 100)
       closed_consumer_check(__method__)
 
       buffer = batch_buffer(max_items)
-      messages = []
+      results = []
 
       count = @native_kafka.with_inner do |_inner|
         Rdkafka::Bindings.rd_kafka_consume_batch_queue(
@@ -837,10 +826,9 @@ module Rdkafka
         )
       end
 
-      return messages if count <= 0
+      return results if count <= 0
 
       i = 0
-      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -853,20 +841,13 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            error = build_batch_error(native_message)
+            results << build_batch_error(native_message)
             Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
             i += 1
-
-            if block_given?
-              yield error
-              first_error ||= error
-              next
-            end
-
-            raise error
+            next
           end
 
-          messages << Rdkafka::Consumer::Message.new(native_message)
+          results << Rdkafka::Consumer::Message.new(native_message)
           Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
           i += 1
         end
@@ -878,8 +859,7 @@ module Rdkafka
         end
       end
 
-      raise first_error if first_error
-      messages
+      results
     end
 
     # Poll for a batch of messages without releasing the GVL (Global VM Lock).
@@ -891,23 +871,17 @@ module Rdkafka
     # @note Since the GVL is not released, a non-zero timeout_ms will block all Ruby
     #   threads/fibers for the duration. Use {#poll_batch} if you need a blocking wait.
     #
-    # Accepts an optional block with the same semantics as {#poll_batch}: when given,
-    # errors are yielded rather than immediately raised, allowing all error events in
-    # the batch to be observed. The first error is still raised after the batch is
-    # fully processed. Normal messages from a batch that also contains errors are
-    # consumed and destroyed but not returned; see {#poll_batch} for details.
+    # Error events are returned inline as {RdkafkaError} objects; see {#poll_batch} for details.
     #
     # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
     # @param max_items [Integer] Maximum number of messages to return per call
-    # @yieldparam error [RdkafkaError] Each error event found in the batch
-    # @return [Array<Message>] Array of messages; empty when any error was encountered
-    # @raise [RdkafkaError] When a consumed message contains an error
+    # @return [Array<Message, RdkafkaError>] Batch of messages and/or error events in arrival order
     # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch_nb(timeout_ms = 0, max_items: 100)
       closed_consumer_check(__method__)
 
       buffer = batch_buffer(max_items)
-      messages = []
+      results = []
 
       count = @native_kafka.with_inner do |_inner|
         Rdkafka::Bindings.rd_kafka_consume_batch_queue_nb(
@@ -918,10 +892,9 @@ module Rdkafka
         )
       end
 
-      return messages if count <= 0
+      return results if count <= 0
 
       i = 0
-      first_error = nil
       begin
         while i < count
           ptr = buffer.get_pointer(i * FFI::Pointer.size)
@@ -934,20 +907,13 @@ module Rdkafka
           native_message = Rdkafka::Bindings::Message.new(ptr)
 
           if native_message[:err] != Rdkafka::Bindings::RD_KAFKA_RESP_ERR_NO_ERROR
-            error = build_batch_error(native_message)
+            results << build_batch_error(native_message)
             Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
             i += 1
-
-            if block_given?
-              yield error
-              first_error ||= error
-              next
-            end
-
-            raise error
+            next
           end
 
-          messages << Rdkafka::Consumer::Message.new(native_message)
+          results << Rdkafka::Consumer::Message.new(native_message)
           Rdkafka::Bindings.rd_kafka_message_destroy(ptr)
           i += 1
         end
@@ -959,8 +925,7 @@ module Rdkafka
         end
       end
 
-      raise first_error if first_error
-      messages
+      results
     end
 
     # Poll for new messages and yield for each received one. Iteration

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -2,7 +2,7 @@
 
 module Rdkafka
   # Current rdkafka-ruby gem version
-  VERSION = "0.27.1"
+  VERSION = "0.27.2"
   # Target librdkafka version to be used
   LIBRDKAFKA_VERSION = "2.14.1"
   # SHA256 hash of the librdkafka source tarball for verification

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1722,7 +1722,7 @@ RSpec.describe Rdkafka::Consumer do
 
     it "yields all errors to the block, continues processing, then raises the first" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
-      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
       ptr2 = msg2.to_ptr
 
@@ -1738,12 +1738,41 @@ RSpec.describe Rdkafka::Consumer do
       consumer.subscribe(topic)
 
       yielded = []
-      expect {
+      raised = nil
+      begin
         consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
-      }.to raise_error(Rdkafka::RdkafkaError)
+      rescue Rdkafka::RdkafkaError => e
+        raised = e
+      end
 
       expect(yielded.size).to eq(2)
       expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+      expect(raised).to be_a(Rdkafka::RdkafkaError)
+      expect(raised.rdkafka_response).to eq(20)
+    end
+
+    it "raises the error and does not return normal messages from a mixed batch" do
+      err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
+      ptr_err = err_msg.to_ptr
+      ptr_ok = ok_msg.to_ptr
+
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr_err)
+      buffer.put_pointer(FFI::Pointer.size, ptr_ok)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
+
+      consumer.subscribe(topic)
+
+      yielded = []
+      expect {
+        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
+      }.to raise_error(Rdkafka::RdkafkaError)
+      expect(yielded.size).to eq(1)
     end
 
     context "when consumer is closed" do
@@ -1824,7 +1853,7 @@ RSpec.describe Rdkafka::Consumer do
 
     it "yields all errors to the block, continues processing, then raises the first" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
-      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
       ptr2 = msg2.to_ptr
 
@@ -1840,12 +1869,41 @@ RSpec.describe Rdkafka::Consumer do
       consumer.subscribe(topic)
 
       yielded = []
-      expect {
+      raised = nil
+      begin
         consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
-      }.to raise_error(Rdkafka::RdkafkaError)
+      rescue Rdkafka::RdkafkaError => e
+        raised = e
+      end
 
       expect(yielded.size).to eq(2)
       expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+      expect(raised).to be_a(Rdkafka::RdkafkaError)
+      expect(raised.rdkafka_response).to eq(20)
+    end
+
+    it "raises the error and does not return normal messages from a mixed batch" do
+      err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
+      ptr_err = err_msg.to_ptr
+      ptr_ok = ok_msg.to_ptr
+
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr_err)
+      buffer.put_pointer(FFI::Pointer.size, ptr_ok)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
+
+      consumer.subscribe(topic)
+
+      yielded = []
+      expect {
+        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
+      }.to raise_error(Rdkafka::RdkafkaError)
+      expect(yielded.size).to eq(1)
     end
 
     context "when consumer is closed" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1720,6 +1720,32 @@ RSpec.describe Rdkafka::Consumer do
       }.to raise_error(Rdkafka::RdkafkaError)
     end
 
+    it "yields all errors to the block, continues processing, then raises the first" do
+      msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ptr1 = msg1.to_ptr
+      ptr2 = msg2.to_ptr
+
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr1)
+      buffer.put_pointer(FFI::Pointer.size, ptr2)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr1)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr2)
+
+      consumer.subscribe(topic)
+
+      yielded = []
+      expect {
+        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
+      }.to raise_error(Rdkafka::RdkafkaError)
+
+      expect(yielded.size).to eq(2)
+      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
+    end
+
     context "when consumer is closed" do
       before { consumer.close }
 
@@ -1794,6 +1820,32 @@ RSpec.describe Rdkafka::Consumer do
       expect {
         consumer.poll_batch_nb(0, max_items: 1)
       }.to raise_error(Rdkafka::RdkafkaError)
+    end
+
+    it "yields all errors to the block, continues processing, then raises the first" do
+      msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
+      ptr1 = msg1.to_ptr
+      ptr2 = msg2.to_ptr
+
+      buffer = FFI::MemoryPointer.new(:pointer, 2)
+      buffer.put_pointer(0, ptr1)
+      buffer.put_pointer(FFI::Pointer.size, ptr2)
+
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
+      allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr1)
+      expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr2)
+
+      consumer.subscribe(topic)
+
+      yielded = []
+      expect {
+        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
+      }.to raise_error(Rdkafka::RdkafkaError)
+
+      expect(yielded.size).to eq(2)
+      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
     end
 
     context "when consumer is closed" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -773,16 +773,26 @@ RSpec.describe Rdkafka::Consumer do
         ).wait
       end
 
-      # Consume to the end
+      # Consume to the end. We wait for assignment before polling so that
+      # partition positions are established — on slow CI (e.g. macOS) the EOF
+      # signal can fire before the first fetch completes if we start polling
+      # immediately, leaving no stored offsets and causing commit to fail.
+      # We also require at least one message to be consumed before stopping,
+      # for the same reason.
       consumer.subscribe(topic)
+      wait_for_assignment(consumer)
       eof_count = 0
+      messages_received = 0
+      deadline = Time.now + 30
       loop do
-        consumer.poll(100)
+        break if Time.now > deadline
+        msg = consumer.poll(100)
+        messages_received += 1 if msg
       rescue Rdkafka::RdkafkaError => error
         if error.is_partition_eof?
           eof_count += 1
         end
-        break if eof_count == 3
+        break if eof_count >= 3 && messages_received.positive?
       end
 
       # Commit

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1701,10 +1701,8 @@ RSpec.describe Rdkafka::Consumer do
       expect(batch.size).to be <= 3
     end
 
-    it "raises an error when a message has an error" do
-      message = Rdkafka::Bindings::Message.new.tap do |msg|
-        msg[:err] = 20
-      end
+    it "returns error events inline rather than raising" do
+      message = Rdkafka::Bindings::Message.new.tap { |msg| msg[:err] = 20 }
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
       buffer.put_pointer(0, message_pointer)
@@ -1715,12 +1713,12 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      expect {
-        consumer.poll_batch(100, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError)
+      results = consumer.poll_batch(100, max_items: 1)
+      expect(results.size).to eq(1)
+      expect(results.first).to be_a(Rdkafka::RdkafkaError)
     end
 
-    it "yields all errors to the block, continues processing, then raises the first" do
+    it "returns multiple error events from a batch in order" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
@@ -1737,21 +1735,12 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      yielded = []
-      raised = nil
-      begin
-        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
-      rescue Rdkafka::RdkafkaError => e
-        raised = e
-      end
-
-      expect(yielded.size).to eq(2)
-      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
-      expect(raised).to be_a(Rdkafka::RdkafkaError)
-      expect(raised.rdkafka_response).to eq(20)
+      results = consumer.poll_batch(100, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results).to all(be_a(Rdkafka::RdkafkaError))
     end
 
-    it "raises the error and does not return normal messages from a mixed batch" do
+    it "returns messages and errors interleaved in arrival order" do
       err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
       ptr_err = err_msg.to_ptr
@@ -1761,20 +1750,19 @@ RSpec.describe Rdkafka::Consumer do
       buffer.put_pointer(0, ptr_err)
       buffer.put_pointer(FFI::Pointer.size, ptr_ok)
 
+      fake_message = double("message")
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
-      # Stub Message.new so we don't call into librdkafka with a fake native struct
-      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(fake_message)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 
       consumer.subscribe(topic)
 
-      yielded = []
-      expect {
-        consumer.poll_batch(100, max_items: 2) { |e| yielded << e }
-      }.to raise_error(Rdkafka::RdkafkaError)
-      expect(yielded.size).to eq(1)
+      results = consumer.poll_batch(100, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results[0]).to be_a(Rdkafka::RdkafkaError)
+      expect(results[1]).to eq(fake_message)
     end
 
     context "when consumer is closed" do
@@ -1834,10 +1822,8 @@ RSpec.describe Rdkafka::Consumer do
       end
     end
 
-    it "raises an error when a message has an error" do
-      message = Rdkafka::Bindings::Message.new.tap do |msg|
-        msg[:err] = 20
-      end
+    it "returns error events inline rather than raising" do
+      message = Rdkafka::Bindings::Message.new.tap { |msg| msg[:err] = 20 }
       message_pointer = message.to_ptr
       buffer = FFI::MemoryPointer.new(:pointer, 1)
       buffer.put_pointer(0, message_pointer)
@@ -1848,12 +1834,12 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      expect {
-        consumer.poll_batch_nb(0, max_items: 1)
-      }.to raise_error(Rdkafka::RdkafkaError)
+      results = consumer.poll_batch_nb(0, max_items: 1)
+      expect(results.size).to eq(1)
+      expect(results.first).to be_a(Rdkafka::RdkafkaError)
     end
 
-    it "yields all errors to the block, continues processing, then raises the first" do
+    it "returns multiple error events from a batch in order" do
       msg1 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       msg2 = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 10 }
       ptr1 = msg1.to_ptr
@@ -1870,21 +1856,12 @@ RSpec.describe Rdkafka::Consumer do
 
       consumer.subscribe(topic)
 
-      yielded = []
-      raised = nil
-      begin
-        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
-      rescue Rdkafka::RdkafkaError => e
-        raised = e
-      end
-
-      expect(yielded.size).to eq(2)
-      expect(yielded).to all(be_a(Rdkafka::RdkafkaError))
-      expect(raised).to be_a(Rdkafka::RdkafkaError)
-      expect(raised.rdkafka_response).to eq(20)
+      results = consumer.poll_batch_nb(0, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results).to all(be_a(Rdkafka::RdkafkaError))
     end
 
-    it "raises the error and does not return normal messages from a mixed batch" do
+    it "returns messages and errors interleaved in arrival order" do
       err_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 20 }
       ok_msg = Rdkafka::Bindings::Message.new.tap { |m| m[:err] = 0 }
       ptr_err = err_msg.to_ptr
@@ -1894,20 +1871,19 @@ RSpec.describe Rdkafka::Consumer do
       buffer.put_pointer(0, ptr_err)
       buffer.put_pointer(FFI::Pointer.size, ptr_ok)
 
+      fake_message = double("message")
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
-      # Stub Message.new so we don't call into librdkafka with a fake native struct
-      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(fake_message)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 
       consumer.subscribe(topic)
 
-      yielded = []
-      expect {
-        consumer.poll_batch_nb(0, max_items: 2) { |e| yielded << e }
-      }.to raise_error(Rdkafka::RdkafkaError)
-      expect(yielded.size).to eq(1)
+      results = consumer.poll_batch_nb(0, max_items: 2)
+      expect(results.size).to eq(2)
+      expect(results[0]).to be_a(Rdkafka::RdkafkaError)
+      expect(results[1]).to eq(fake_message)
     end
 
     context "when consumer is closed" do

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1475,14 +1475,30 @@ RSpec.describe Rdkafka::Consumer do
       expect_eof_details(error, topic)
     end
 
-    it "raises :partition_eof with topic/partition/offset details via #poll_batch" do
-      error = collect_eof_error(consumer) { consumer.poll_batch(100, max_items: 10) }
-      expect_eof_details(error, topic)
+    it "returns :partition_eof with topic/partition/offset details via #poll_batch" do
+      consumer.subscribe(topic)
+      eof_error = nil
+      deadline = Time.now + 30
+      loop do
+        break if Time.now > deadline
+        results = consumer.poll_batch(100, max_items: 10)
+        eof_error = results.find { |r| r.is_a?(Rdkafka::RdkafkaError) && r.is_partition_eof? }
+        break if eof_error
+      end
+      expect_eof_details(eof_error, topic)
     end
 
-    it "raises :partition_eof with topic/partition/offset details via #poll_batch_nb" do
-      error = collect_eof_error(consumer) { consumer.poll_batch_nb(100, max_items: 10) }
-      expect_eof_details(error, topic)
+    it "returns :partition_eof with topic/partition/offset details via #poll_batch_nb" do
+      consumer.subscribe(topic)
+      eof_error = nil
+      deadline = Time.now + 30
+      loop do
+        break if Time.now > deadline
+        results = consumer.poll_batch_nb(100, max_items: 10)
+        eof_error = results.find { |r| r.is_a?(Rdkafka::RdkafkaError) && r.is_partition_eof? }
+        break if eof_error
+      end
+      expect_eof_details(eof_error, topic)
     end
   end
 

--- a/spec/lib/rdkafka/consumer_spec.rb
+++ b/spec/lib/rdkafka/consumer_spec.rb
@@ -1763,6 +1763,8 @@ RSpec.describe Rdkafka::Consumer do
 
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      # Stub Message.new so we don't call into librdkafka with a fake native struct
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 
@@ -1894,6 +1896,8 @@ RSpec.describe Rdkafka::Consumer do
 
       expect(Rdkafka::Bindings).to receive(:rd_kafka_consume_batch_queue_nb).and_return(2)
       allow(consumer).to receive_messages(batch_buffer: buffer, consumer_queue: FFI::Pointer::NULL)
+      # Stub Message.new so we don't call into librdkafka with a fake native struct
+      allow(Rdkafka::Consumer::Message).to receive(:new).and_return(double("message"))
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_err)
       expect(Rdkafka::Bindings).to receive(:rd_kafka_message_destroy).with(ptr_ok)
 


### PR DESCRIPTION
…rror

Previously, when an error (e.g. :partition_eof) appeared in a batch returned by rd_kafka_consume_batch_queue, the code raised immediately inside the begin block. Control jumped to the ensure clause which destroyed all remaining native message pointers — including any subsequent EOF or other error events from other partitions. Those events were permanently lost.

Both methods now accept an optional block. When a block is given:
- Each error encountered is built from the native message struct (preserving topic/partition/offset details and fatal-error detection) before the pointer is destroyed.
- The error is yielded to the block and processing continues for the remaining items in the batch.
- The first error is stored and raised after the loop completes and the ensure clause has cleaned up any remaining pointers.

Without a block the behaviour is unchanged: the first error halts the loop and is raised, with ensure handling cleanup of remaining pointers.

This allows callers to observe all error events in a batch — for example, EOF signals from multiple partitions that arrive simultaneously in a single rd_kafka_consume_batch_queue call.