### PR TITLE
Add retry backoff loop for docker compose Kafka startup

### DIFF
--- a/.github/workflows/ci_linux_alpine_aarch64_musl.yml
+++ b/.github/workflows/ci_linux_alpine_aarch64_musl.yml
@@ -72,7 +72,12 @@ jobs:
 
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -175,7 +180,12 @@ jobs:
 
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
 

--- a/.github/workflows/ci_linux_alpine_aarch64_musl_complementary.yml
+++ b/.github/workflows/ci_linux_alpine_aarch64_musl_complementary.yml
@@ -123,7 +123,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -219,7 +224,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
 

--- a/.github/workflows/ci_linux_alpine_x86_64_musl.yml
+++ b/.github/workflows/ci_linux_alpine_x86_64_musl.yml
@@ -69,7 +69,12 @@ jobs:
 
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -166,7 +171,12 @@ jobs:
           path: ext/
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
 

--- a/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
+++ b/.github/workflows/ci_linux_alpine_x86_64_musl_complementary.yml
@@ -120,7 +120,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -211,7 +216,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
 

--- a/.github/workflows/ci_linux_debian_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu.yml
@@ -76,7 +76,12 @@ jobs:
 
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -235,7 +240,12 @@ jobs:
           path: ext/
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do

--- a/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_debian_x86_64_gnu_complementary.yml
@@ -149,7 +149,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do
@@ -272,7 +277,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
           sleep 10
           for i in {1..30}; do

--- a/.github/workflows/ci_linux_ubuntu_aarch64_gnu.yml
+++ b/.github/workflows/ci_linux_ubuntu_aarch64_gnu.yml
@@ -84,7 +84,12 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -223,7 +228,12 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10

--- a/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_aarch64_gnu_complementary.yml
@@ -156,7 +156,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -243,7 +248,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
@@ -82,7 +82,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -224,7 +229,12 @@ jobs:
           bundler-cache: false
       - name: Start Kafka with Docker Compose
         run: |
-          docker compose -f docker-compose.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu_complementary.yml
@@ -149,7 +149,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10
@@ -233,7 +238,12 @@ jobs:
       - name: Start Kafka with Docker Compose
         run: |
           ./ext/generate-ssl-certs.sh
-          docker compose -f docker-compose-ssl.yml up -d
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose-ssl.yml up -d && break
+            echo "Attempt $attempt/5 failed."
+            docker compose -f docker-compose-ssl.yml down -v 2>/dev/null || true
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
+          done
           echo "Waiting for Kafka to be ready..."
 
           sleep 10


### PR DESCRIPTION
Docker Hub registry occasionally times out on GH Actions infrastructure. Replace single docker compose up with a 5-attempt retry loop using linear backoff (15s/30s/45s/60s) and compose down between retries.