### PR TITLE
Remove dead per-message topic_name allocation in delivery callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rdkafka Changelog
 
+## Unreleased
+- [Enhancement] Remove the unused `DeliveryHandle` `:topic_name` struct field and the per-message allocation that populated it. The delivery callback copied the topic name into a native `FFI::MemoryPointer` on every delivered message, retained for the lifetime of the handle, yet nothing ever read it: the topic is already available via `DeliveryHandle#topic` (a Ruby attribute set during `produce`) and `DeliveryReport#topic_name`, both of which work exactly as before.
+
 ## 0.27.2 (2026-05-21)
 - [Enhancement] `poll_batch` and `poll_batch_nb` now return error events inline as `RdkafkaError` objects rather than raising on the first error. The return type is `Array<Message, RdkafkaError>` and callers are responsible for handling errors in the result.
 

--- a/lib/rdkafka/callbacks.rb
+++ b/lib/rdkafka/callbacks.rb
@@ -453,7 +453,9 @@ module Rdkafka
           delivery_handle[:response] = message[:err]
           delivery_handle[:partition] = message[:partition]
           delivery_handle[:offset] = message[:offset]
-          delivery_handle[:topic_name] = FFI::MemoryPointer.from_string(topic_name)
+          # The topic is not stored on the handle here: it is already set as the handle's
+          # `topic` Ruby attribute during produce, which spares a native string copy that
+          # would otherwise be allocated and retained for every message.
 
           # Call delivery callback on opaque
           if opaque = Rdkafka::Config.opaques[opaque_ptr.to_i]

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -8,14 +8,14 @@ module Rdkafka
       layout :pending, :bool,
         :response, :int,
         :partition, :int,
-        :offset, :int64,
-        :topic_name, :pointer
+        :offset, :int64
 
       # @return [Object, nil] label set during message production or nil by default
       attr_accessor :label
 
       # @return [String] topic where we are trying to send the message
-      # We use this instead of reading from `topic_name` pointer to save on memory allocations
+      # Set in `#produce`, where the topic is known upfront. Keeping it as a Ruby attribute
+      # spares a per-message native string copy in the delivery callback.
       attr_accessor :topic
 
       # @return [String] the name of the operation (e.g. "delivery")

--- a/spec/lib/rdkafka/producer_spec.rb
+++ b/spec/lib/rdkafka/producer_spec.rb
@@ -276,6 +276,21 @@ RSpec.describe Rdkafka::Producer do
     expect(message.timestamp).to be_within(10).of(Time.now)
   end
 
+  it "carries the topic name via the handle topic attribute" do
+    handle = producer.produce(
+      topic: topic,
+      payload: "payload",
+      key: "key"
+    )
+
+    report = handle.wait(max_wait_timeout_ms: 5_000)
+
+    # The topic name is carried via the handle's `topic` Ruby attribute set during produce,
+    # so no per-message native copy is allocated on delivery
+    expect(handle.topic).to eq topic
+    expect(report.topic_name).to eq topic
+  end
+
   it "produces a message with a specified partition" do
     # Produce a message
     handle = producer.produce(


### PR DESCRIPTION
The delivery callback copied the topic name into a native FFI::MemoryPointer and stored it in the DeliveryHandle :topic_name struct field on every delivered message. Nothing reads that field: DeliveryHandle#create_result deliberately uses the topic Ruby attribute set during produce. Because FFI structs pin pointer-member references, the copy was also retained for the full lifetime of the handle.

Dropping the assignment saves two Ruby objects, one native malloc and a string copy per delivered message. The :topic_name field stays in the struct layout for compatibility but is left NULL.