### PR TITLE
Expose partition replicas and isrs in topic metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Rdkafka Changelog
 
 ## Unreleased
+- [Enhancement] Expose `replicas` and `isrs` (in-sync replica broker ids) on each partition in topic metadata (`Metadata#topics` partition hashes). The base struct `#to_h` skips FFI pointer members, so these two arrays were dropped entirely and the partition replica assignment was unavailable to callers (e.g. for planning replication-factor changes). `PartitionMetadata#to_h` now dereferences both pointers into arrays of broker ids.
 - [Enhancement] Reuse per-thread scratch pointers in `Consumer::Headers.from_native` instead of allocating them for every consumed message. Previously each message paid one native pointer allocation just to check for headers and three more when headers were present; now the scratch pointers are allocated once per thread/fiber and reused, removing all per-message native scratch allocations from the consumer hot path.
 - [Enhancement] Remove the unused `DeliveryHandle` `:topic_name` struct field and the per-message allocation that populated it. The delivery callback copied the topic name into a native `FFI::MemoryPointer` on every delivered message, retained for the lifetime of the handle, yet nothing ever read it: the topic is already available via `DeliveryHandle#topic` (a Ruby attribute set during `produce`) and `DeliveryReport#topic_name`, both of which work exactly as before.
 

--- a/lib/rdkafka/metadata.rb
+++ b/lib/rdkafka/metadata.rb
@@ -134,6 +134,36 @@ module Rdkafka
         :replicas, :pointer,
         :in_sync_replica_brokers, :int,
         :isrs, :pointer
+
+      # The base `#to_h` skips FFI pointer members, which would drop the replica and in-sync
+      # replica assignments entirely. We dereference those pointers here so the partition hash
+      # exposes the broker ids backing the partition (needed e.g. to plan replication changes).
+      #
+      # @return [Hash{Symbol => Integer, Array<Integer>}] partition metadata:
+      #   * +:partition_id+ (Integer) - partition id
+      #   * +:leader+ (Integer) - broker id of the partition leader
+      #   * +:replica_count+ (Integer) - number of assigned replicas
+      #   * +:in_sync_replica_brokers+ (Integer) - number of in-sync replicas
+      #   * +:replicas+ (Array<Integer>) - broker ids of the assigned replicas
+      #   * +:isrs+ (Array<Integer>) - broker ids of the in-sync replicas
+      def to_h
+        super.merge(
+          replicas: read_broker_ids(self[:replicas], self[:replica_count]),
+          isrs: read_broker_ids(self[:isrs], self[:in_sync_replica_brokers])
+        )
+      end
+
+      private
+
+      # Reads `count` broker ids (int32) from a replicas/isrs pointer.
+      # @param pointer [FFI::Pointer] pointer to the broker ids array
+      # @param count [Integer] number of broker ids to read
+      # @return [Array<Integer>] broker ids (empty when there are none)
+      def read_broker_ids(pointer, count)
+        return [] if count.zero? || pointer.null?
+
+        pointer.read_array_of_int32(count)
+      end
     end
   end
 end

--- a/spec/lib/rdkafka/metadata_spec.rb
+++ b/spec/lib/rdkafka/metadata_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Rdkafka::Metadata do
         expect(metadata.topics[0][:partitions].length).to eq(25)
         expect(metadata.topics[0][:topic_name]).to eq(topic_name)
       end
+
+      it "#topics exposes the replica and in-sync replica broker ids per partition" do
+        metadata.topics[0][:partitions].each do |partition|
+          expect(partition[:replicas]).to eq([1])
+          expect(partition[:isrs]).to eq([1])
+          expect(partition[:replica_count]).to eq(1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The base CustomFFIStruct#to_h skips FFI pointer members, so PartitionMetadata's :replicas and :isrs pointers were dropped entirely - the partition replica assignment was unavailable to callers (e.g. Karafka::Admin replication-factor planning, which reads partition[:replicas] and always got nil). PartitionMetadata#to_h now dereferences both pointers into arrays of broker ids using the matching :replica_count / :in_sync_replica_brokers counts.

Covered in metadata_spec by asserting each partition exposes replicas/isrs for the single-broker test cluster.