### PR TITLE
Adopt the yard-lint 1.10 documentation standard

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -64,6 +64,33 @@ Documentation/BlankLineBeforeDefinition:
     SingleBlankLine: true
     OrphanedDocs: true
 
+Documentation/DuplicateNamespaceComment:
+  Description: Detects namespaces documented with a YARD comment in more than one file.
+  Enabled: true
+  Severity: error
+
+Documentation/UnderfilledLines:
+  Description: Detects documentation prose that wraps too early and wastes horizontal space.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength.
+  MaxLength: 100
+
+Documentation/LineLength:
+  Description: Detects documentation lines that exceed the maximum length.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength.
+  MaxLength: 100
+
+Documentation/TextSubstitution:
+  Description: Detects em/en-dashes in documentation and replaces them with hyphens.
+  Enabled: true
+  Severity: error
+  Substitutions:
+    "—": "-"    # em-dash
+    "–": "-"    # en-dash
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.
@@ -72,9 +99,15 @@ Tags/Order:
   EnforcedOrder:
   - param
   - option
+  - yield
+  - yieldparam
+  - yieldreturn
   - return
   - raise
+  - see
   - example
+  - note
+  - todo
 
 Tags/InvalidTypes:
   Description: Validates type definitions in @param, @return, @option tags.
@@ -144,7 +177,7 @@ Tags/OptionTags:
 Tags/ExampleSyntax:
   Description: Validates Ruby syntax in @example tags.
   Enabled: true
-  Severity: warning
+  Severity: error
 
 Tags/RedundantParamDescription:
   Description: Detects meaningless parameter descriptions that add no value.

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -70,11 +70,11 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    yard (0.9.38)
-    yard-lint (1.4.0)
+    yard (0.9.45)
+    yard-lint (1.10.2)
       yard (~> 0.9)
       zeitwerk (~> 2.6)
-    zeitwerk (2.7.4)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   ruby
@@ -115,9 +115,9 @@ CHECKSUMS
   standard-rspec (0.4.0) sha256=0fdf64c887cd6404f1c3a1435b14ba6fde2e9e80c0f4dafe4b04a67f673db262
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
-  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
-  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
-  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
+  yard-lint (1.10.2) sha256=3e595709d088a8cc827e706a4146b447eb6a907ee375d06c11077369d00717f6
+  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH
   4.0.3

--- a/lib/rdkafka/admin.rb
+++ b/lib/rdkafka/admin.rb
@@ -108,10 +108,6 @@ module Rdkafka
     # @return [nil]
     # @raise [Rdkafka::ClosedAdminError] if called on a closed admin client
     #
-    # @note This method holds the inner lock until the queue is empty or `:stop` is returned.
-    #   Other admin operations will wait until this method returns.
-    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
-    #
     # @example Drain all pending events
     #   admin.events_poll_nb_each { |_count| }
     #
@@ -120,6 +116,9 @@ module Rdkafka
     #   admin.events_poll_nb_each do |_count|
     #     :stop if monotonic_now >= deadline
     #   end
+    # @note This method holds the inner lock until the queue is empty or `:stop` is returned.
+    #   Other admin operations will wait until this method returns.
+    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
     def events_poll_nb_each
       closed_admin_check(__method__)
 
@@ -345,7 +344,8 @@ module Rdkafka
     #
     # @param topic_name [String] name of the topic
     # @param partition_count [Integer] how many partitions we want to end up with for given topic
-    # @return [CreatePartitionsHandle] Create partitions handle that can be used to wait for the result
+    # @return [CreatePartitionsHandle] Create partitions handle that can be used to wait for
+    #   the result
     # @raise [ConfigError] When the partition count or replication factor are out of valid range
     # @raise [RdkafkaError] When the topic name is invalid or the topic already exists
     # @raise [RdkafkaError] When the topic configuration is invalid
@@ -434,7 +434,8 @@ module Rdkafka
     # @param permission_type [Integer] rd_kafka_AclPermissionType_t value:
     #   - RD_KAFKA_ACL_PERMISSION_TYPE_DENY  = 2
     #   - RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW = 3
-    # @return [CreateAclHandle] Create acl handle that can be used to wait for the result of creating the acl
+    # @return [CreateAclHandle] Create acl handle that can be used to wait for the result of
+    #   creating the acl
     # @raise [RdkafkaError]
     def create_acl(resource_type:, resource_name:, resource_pattern_type:, principal:, host:, operation:, permission_type:)
       closed_admin_check(__method__)
@@ -535,7 +536,8 @@ module Rdkafka
     # @param permission_type [Integer] rd_kafka_AclPermissionType_t value:
     #   - RD_KAFKA_ACL_PERMISSION_TYPE_DENY  = 2
     #   - RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW = 3
-    # @return [DeleteAclHandle] Delete acl handle that can be used to wait for the result of deleting the acl
+    # @return [DeleteAclHandle] Delete acl handle that can be used to wait for the result of
+    #   deleting the acl
     # @raise [RdkafkaError]
     def delete_acl(resource_type:, resource_name:, resource_pattern_type:, principal:, host:, operation:, permission_type:)
       closed_admin_check(__method__)
@@ -638,7 +640,8 @@ module Rdkafka
     # @param permission_type [Integer] rd_kafka_AclPermissionType_t value:
     #   - RD_KAFKA_ACL_PERMISSION_TYPE_DENY  = 2
     #   - RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW = 3
-    # @return [DescribeAclHandle] Describe acl handle that can be used to wait for the result of fetching acls
+    # @return [DescribeAclHandle] Describe acl handle that can be used to wait for the result of
+    #   fetching acls
     # @raise [RdkafkaError]
     def describe_acl(resource_type:, resource_name:, resource_pattern_type:, principal:, host:, operation:, permission_type:)
       closed_admin_check(__method__)

--- a/lib/rdkafka/admin/create_acl_report.rb
+++ b/lib/rdkafka/admin/create_acl_report.rb
@@ -4,7 +4,8 @@ module Rdkafka
   class Admin
     # Report for create ACL operation result
     class CreateAclReport
-      # Upon successful creation of Acl RD_KAFKA_RESP_ERR_NO_ERROR - 0 is returned as rdkafka_response
+      # Upon successful creation of Acl RD_KAFKA_RESP_ERR_NO_ERROR - 0 is returned as
+      #   rdkafka_response
       # @return [Integer]
       attr_reader :rdkafka_response
 

--- a/lib/rdkafka/admin/describe_acl_report.rb
+++ b/lib/rdkafka/admin/describe_acl_report.rb
@@ -4,7 +4,8 @@ module Rdkafka
   class Admin
     # Report for describe ACL operation result
     class DescribeAclReport
-      # acls that exists in the cluster for the resource_type, resource_name and pattern_type filters provided in the request.
+      # acls that exists in the cluster for the resource_type, resource_name and pattern_type
+      #   filters provided in the request.
       # @return [Rdkafka::Bindings::AclBindingResult] array of matching acls.
       attr_reader :acls
 

--- a/lib/rdkafka/bindings.rb
+++ b/lib/rdkafka/bindings.rb
@@ -88,7 +88,7 @@ module Rdkafka
 
     # This function comes from our patch on top of librdkafka. It allows os to load all the
     # librdkafka components without initializing the client
-    # @see https://github.com/confluentinc/librdkafka/issues/4590
+    # See: https://github.com/confluentinc/librdkafka/issues/4590
     attach_function :rd_kafka_global_init, [], :void
 
     # Polling
@@ -271,10 +271,11 @@ module Rdkafka
 
     # Queue IO Event Support - for fiber scheduler integration
     # Enables notifications to a custom FD when queue transitions from empty to non-empty
-    # @param queue rd_kafka_queue_t* - the queue to monitor
-    # @param fd int - file descriptor to write to (provide your own pipe/eventfd)
-    # @param payload const void* - data to write to fd
-    # @param size size_t - size of payload
+    # Arguments:
+    # - queue (rd_kafka_queue_t*) - the queue to monitor
+    # - fd (int) - file descriptor to write to (provide your own pipe/eventfd)
+    # - payload (const void*) - data to write to fd
+    # - size (size_t) - size of payload
     attach_function :rd_kafka_queue_io_event_enable, [:pointer, :int, :pointer, :size_t], :void
     # Per topic configs
     attach_function :rd_kafka_topic_conf_new, [], :pointer
@@ -343,7 +344,8 @@ module Rdkafka
     # across different parts of the codebase (callbacks, testing utilities, etc.).
     #
     # @param client_ptr [FFI::Pointer] Native kafka client pointer
-    # @return [Hash, nil] Hash with :error_code and :error_string if fatal error occurred, nil otherwise
+    # @return [Hash, nil] Hash with :error_code and :error_string if fatal error occurred,
+    #   nil otherwise
     #
     # @example
     #   details = Rdkafka::Bindings.extract_fatal_error(client_ptr)
@@ -389,8 +391,9 @@ module Rdkafka
     end
 
     # The OAuth callback is currently global and contextless.
-    # This means that the callback will be called for all instances, and the callback must be able to determine to which instance it is associated.
-    # The instance name will be provided in the callback, allowing the callback to reference the correct instance.
+    # This means that the callback will be called for all instances, and the callback must be able
+    # to determine to which instance it is associated. The instance name will be provided in the
+    # callback, allowing the callback to reference the correct instance.
     #
     # An example of how to use the instance name in the callback is given below.
     # The `refresh_token` is configured as the `oauthbearer_token_refresh_callback`.
@@ -661,21 +664,24 @@ module Rdkafka
     attach_function :rd_kafka_AclBindingFilter_new, [:int32, :pointer, :int32, :pointer, :pointer, :int32, :int32, :pointer, :size_t], :pointer
     attach_function :rd_kafka_AclBinding_destroy, [:pointer], :void
 
-    # rd_kafka_ResourceType_t - https://github.com/confluentinc/librdkafka/blob/292d2a66b9921b783f08147807992e603c7af059/src/rdkafka.h#L7307
+    # rd_kafka_ResourceType_t -
+    # https://github.com/confluentinc/librdkafka/blob/292d2a66b992/src/rdkafka.h#L7307
     RD_KAFKA_RESOURCE_ANY = 1
     RD_KAFKA_RESOURCE_TOPIC = 2
     RD_KAFKA_RESOURCE_GROUP = 3
     RD_KAFKA_RESOURCE_BROKER = 4
     RD_KAFKA_RESOURCE_TRANSACTIONAL_ID = 5
 
-    # rd_kafka_ResourcePatternType_t - https://github.com/confluentinc/librdkafka/blob/292d2a66b9921b783f08147807992e603c7af059/src/rdkafka.h#L7320
+    # rd_kafka_ResourcePatternType_t -
+    # https://github.com/confluentinc/librdkafka/blob/292d2a66b992/src/rdkafka.h#L7320
     RD_KAFKA_RESOURCE_PATTERN_UNKNOWN = 0
     RD_KAFKA_RESOURCE_PATTERN_ANY = 1
     RD_KAFKA_RESOURCE_PATTERN_MATCH = 2
     RD_KAFKA_RESOURCE_PATTERN_LITERAL = 3
     RD_KAFKA_RESOURCE_PATTERN_PREFIXED = 4
 
-    # rd_kafka_AclOperation_t - https://github.com/confluentinc/librdkafka/blob/292d2a66b9921b783f08147807992e603c7af059/src/rdkafka.h#L8403
+    # rd_kafka_AclOperation_t -
+    # https://github.com/confluentinc/librdkafka/blob/292d2a66b992/src/rdkafka.h#L8403
     RD_KAFKA_ACL_OPERATION_ANY = 1
     RD_KAFKA_ACL_OPERATION_ALL = 2
     RD_KAFKA_ACL_OPERATION_READ = 3
@@ -689,7 +695,8 @@ module Rdkafka
     RD_KAFKA_ACL_OPERATION_ALTER_CONFIGS = 11
     RD_KAFKA_ACL_OPERATION_IDEMPOTENT_WRITE = 12
 
-    # rd_kafka_AclPermissionType_t - https://github.com/confluentinc/librdkafka/blob/292d2a66b9921b783f08147807992e603c7af059/src/rdkafka.h#L8435
+    # rd_kafka_AclPermissionType_t -
+    # https://github.com/confluentinc/librdkafka/blob/292d2a66b992/src/rdkafka.h#L8435
     RD_KAFKA_ACL_PERMISSION_TYPE_ANY = 1
     RD_KAFKA_ACL_PERMISSION_TYPE_DENY = 2
     RD_KAFKA_ACL_PERMISSION_TYPE_ALLOW = 3

--- a/lib/rdkafka/callbacks.rb
+++ b/lib/rdkafka/callbacks.rb
@@ -286,9 +286,9 @@ module Rdkafka
       end
     end
 
-    # @private
+    # @!visibility private
     @@mutex = Mutex.new
-    # @private
+    # @!visibility private
     @@current_pid = nil
 
     class << self

--- a/lib/rdkafka/config.rb
+++ b/lib/rdkafka/config.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  # Configuration for a Kafka consumer or producer. You can create an instance and use
-  # the consumer and producer methods to create a client. Documentation of the available
-  # configuration options is available on https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md.
+  # Configuration for a Kafka consumer or producer. You can create an instance and use the
+  # consumer and producer methods to create a client. Documentation of the available configuration
+  # options is available on
+  # https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
   class Config
-    # @private
+    # @!visibility private
     @@logger = Logger.new($stdout)
-    # @private
+    # @!visibility private
     @@statistics_callback = nil
-    # @private
+    # @!visibility private
     @@error_callback = nil
-    # @private
+    # @!visibility private
     @@opaques = ObjectSpace::WeakMap.new
-    # @private
+    # @!visibility private
     @@log_queue = Queue.new
-    # We memoize thread on the first log flush
-    # This allows us also to restart logger thread on forks
+    # We memoize thread on the first log flush This allows us also to restart logger thread on forks
     @@log_thread = nil
-    # @private
+    # @!visibility private
     @@log_mutex = Mutex.new
-    # @private
+    # @!visibility private
     @@oauthbearer_token_refresh_callback = nil
 
     # Returns the current logger, by default this is a logger to stdout.
@@ -69,7 +69,8 @@ module Rdkafka
 
     # Set a callback that will be called every time the underlying client emits statistics.
     # You can configure if and how often this happens using `statistics.interval.ms`.
-    # The callback is called with a hash that's documented here: https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
+    # The callback is called with a hash that's documented here:
+    # https://github.com/confluentinc/librdkafka/blob/master/STATISTICS.md
     #
     # @param callback [Proc, #call, nil] callable object or nil to clear
     # @return [nil]
@@ -86,7 +87,8 @@ module Rdkafka
     end
 
     # Set a callback that will be called every time the underlying client emits an error.
-    # If this callback is not set, global errors such as brokers becoming unavailable will only be sent to the logger, as defined by librdkafka.
+    # If this callback is not set, global errors such as brokers becoming unavailable will only be
+    # sent to the logger, as defined by librdkafka.
     # The callback is called with an instance of RdKafka::Error.
     #
     # @param callback [Proc, #call, nil] callable object to handle errors or nil to clear
@@ -295,6 +297,9 @@ module Rdkafka
     # Uses `rd_kafka_conf_dump` to retrieve every property (including defaults and
     # internal properties like `client.software.name`) as a flat Hash.
     #
+    # @return [Hash{Symbol => String}] property names mapped to their current values
+    #
+    # @raise [ConfigError] When the configuration contains invalid options
     # @note The librdkafka C API does not distinguish between producer-only, consumer-only,
     #   and global properties at the configuration level. All properties are returned
     #   regardless of the intended client type.
@@ -302,10 +307,6 @@ module Rdkafka
     # @note The returned Hash may include sensitive values such as authentication
     #   credentials and key passwords. Do not log or serialize the returned data
     #   unless you have explicitly redacted secret entries.
-    #
-    # @return [Hash{Symbol => String}] property names mapped to their current values
-    #
-    # @raise [ConfigError] When the configuration contains invalid options
     def describe_properties
       config = nil
       dump_ptr = nil
@@ -330,7 +331,8 @@ module Rdkafka
       Rdkafka::Bindings.rd_kafka_conf_destroy(config) if config
     end
 
-    # Error that is returned by the underlying rdkafka error if an invalid configuration option is present.
+    # Error that is returned by the underlying rdkafka error if an invalid configuration option is
+    # present.
     class ConfigError < RuntimeError; end
 
     # Error that is returned by the underlying rdkafka library if the client cannot be created.

--- a/lib/rdkafka/consumer.rb
+++ b/lib/rdkafka/consumer.rb
@@ -35,11 +35,13 @@ module Rdkafka
     # consumer-queue reference, then destroy the native client. The default `NativeKafka#finalizer`
     # went straight to `rd_kafka_destroy`, leaving the consumer-queue reference (from
     # `rd_kafka_queue_get_consumer`, taken by `poll_batch`) dangling - which can make
-    # `rd_kafka_destroy` block inside the finalizer (process hang at GC/shutdown) or leak the handle.
+    # `rd_kafka_destroy` block inside the finalizer (process hang at GC/shutdown) or leak the
+    # handle.
     #
     # @private
     # @param native_kafka [NativeKafka] the wrapped native client
-    # @param queue_holder [Array] single-element holder carrying the consumer queue pointer (or empty)
+    # @param queue_holder [Array] single-element holder carrying the consumer queue pointer (or
+    #   empty)
     # @return [Proc] finalizer proc that must not reference the consumer instance
     def self.finalizer(native_kafka, queue_holder)
       proc do
@@ -125,11 +127,6 @@ module Rdkafka
     # @return [nil]
     # @raise [Rdkafka::ClosedConsumerError] if called on a closed consumer
     #
-    # @note This method holds the inner lock until the queue is empty or `:stop` is returned.
-    #   Other consumer operations will wait until this method returns.
-    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
-    # @note Do NOT use this if `consumer_poll_set` was set to `true`
-    #
     # @example Drain all pending events
     #   consumer.events_poll_nb_each { |_count| }
     #
@@ -138,6 +135,10 @@ module Rdkafka
     #   consumer.events_poll_nb_each do |_count|
     #     :stop if monotonic_now >= deadline
     #   end
+    # @note This method holds the inner lock until the queue is empty or `:stop` is returned.
+    #   Other consumer operations will wait until this method returns.
+    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
+    # @note Do NOT use this if `consumer_poll_set` was set to `true`
     def events_poll_nb_each
       closed_consumer_check(__method__)
 
@@ -163,14 +164,6 @@ module Rdkafka
     # @raise [Rdkafka::ClosedConsumerError] if called on a closed consumer
     # @raise [Rdkafka::RdkafkaError] if a Kafka error occurs while polling
     #
-    # @note This method uses `rd_kafka_consumer_poll` to fetch messages, unlike
-    #   `events_poll_nb_each` which uses `rd_kafka_poll` for event callbacks (delivery reports,
-    #   statistics, etc.). For consumers, use this method to receive messages and
-    #   `events_poll_nb_each` for processing background events.
-    # @note This method holds the inner lock for the duration. Other consumer operations
-    #   will wait until this method returns.
-    # @note Timeout/max_messages logic should be implemented by the caller
-    #
     # @example Process messages until queue is empty
     #   consumer.poll_nb_each do |message|
     #     process(message)
@@ -183,6 +176,13 @@ module Rdkafka
     #     count += 1
     #     :stop if count >= 10
     #   end
+    # @note This method uses `rd_kafka_consumer_poll` to fetch messages, unlike
+    #   `events_poll_nb_each` which uses `rd_kafka_poll` for event callbacks (delivery reports,
+    #   statistics, etc.). For consumers, use this method to receive messages and
+    #   `events_poll_nb_each` for processing background events.
+    # @note This method holds the inner lock for the duration. Other consumer operations
+    #   will wait until this method returns.
+    # @note Timeout/max_messages logic should be implemented by the caller
     def poll_nb_each
       closed_consumer_check(__method__)
 
@@ -437,9 +437,11 @@ module Rdkafka
     end
 
     # Return the current positions (offsets) for topics and partitions.
-    # The offset field of each requested partition will be set to the offset of the last consumed message + 1, or nil in case there was no previous message.
+    # The offset field of each requested partition will be set to the offset of the last consumed
+    # message + 1, or nil in case there was no previous message.
     #
-    # @param list [TopicPartitionList, nil] The topic with partitions to get the offsets for or nil to use the current subscription.
+    # @param list [TopicPartitionList, nil] The topic with partitions to get the offsets for or nil
+    #   to use the current subscription.
     #
     # @return [TopicPartitionList]
     #
@@ -646,9 +648,8 @@ module Rdkafka
       seek_by(message.topic, message.partition, message.offset)
     end
 
-    # Seek to a particular message by providing the topic, partition and offset.
-    # The next poll on the topic/partition will return the
-    # message at the given offset.
+    # Seek to a particular message by providing the topic, partition and offset. The next poll on
+    # the topic/partition will return the message at the given offset.
     #
     # @param topic [String] The topic in which to seek
     # @param partition [Integer] The partition number to seek
@@ -875,7 +876,7 @@ module Rdkafka
     # returns without further waiting.
     #
     # Error events (e.g. `:partition_eof`) are returned inline as {RdkafkaError} objects
-    # rather than raised, so callers receive the complete batch — both messages and errors —
+    # rather than raised, so callers receive the complete batch - both messages and errors -
     # and can decide how to handle each. This is particularly useful when multiple partitions
     # signal EOF simultaneously: all signals appear in the returned array rather than only
     # the first one being raised and the rest silently discarded.
@@ -950,15 +951,15 @@ module Rdkafka
     # particularly useful in fiber scheduler contexts where GVL release/reacquire
     # overhead is wasteful since we don't expect to wait.
     #
+    # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for
+    #   non-blocking)
+    # @param max_items [Integer] Maximum number of messages to return per call
+    # @return [Array<Message, RdkafkaError>] Batch of messages and/or error events in arrival order
+    # @raise [ClosedConsumerError] When called on a closed consumer
     # @note Since the GVL is not released, a non-zero timeout_ms will block all Ruby
     #   threads/fibers for the duration. Use {#poll_batch} if you need a blocking wait.
     #
     # Error events are returned inline as {RdkafkaError} objects; see {#poll_batch} for details.
-    #
-    # @param timeout_ms [Integer] Timeout waiting for the first message (default: 0 for non-blocking)
-    # @param max_items [Integer] Maximum number of messages to return per call
-    # @return [Array<Message, RdkafkaError>] Batch of messages and/or error events in arrival order
-    # @raise [ClosedConsumerError] When called on a closed consumer
     def poll_batch_nb(timeout_ms = 0, max_items: 100)
       closed_consumer_check(__method__)
 

--- a/lib/rdkafka/consumer/topic_partition_list.rb
+++ b/lib/rdkafka/consumer/topic_partition_list.rb
@@ -6,7 +6,8 @@ module Rdkafka
     class TopicPartitionList
       # Create a topic partition list.
       #
-      # @param data [Hash{String => nil,Partition}] The topic and partition data or nil to create an empty list
+      # @param data [Hash{String => nil,Partition}] The topic and partition data or nil to create an
+      #   empty list
       #
       # @return [TopicPartitionList]
       def initialize(data = nil)
@@ -34,10 +35,12 @@ module Rdkafka
       end
 
       # Add a topic with optionally partitions to the list.
-      # Calling this method multiple times for the same topic will overwrite the previous configuraton.
+      # Calling this method multiple times for the same topic will overwrite the previous
+      # configuraton.
       #
       # @param topic [String] The topic's name
-      # @param partitions [Array<Integer>, Range<Integer>, Integer] The topic's partitions or partition count
+      # @param partitions [Array<Integer>, Range<Integer>, Integer] The topic's partitions or
+      #   partition count
       #
       # @return [nil]
       #
@@ -61,11 +64,12 @@ module Rdkafka
       end
 
       # Add a topic with partitions and offsets set to the list
-      # Calling this method multiple times for the same topic will overwrite the previous configuraton.
+      # Calling this method multiple times for the same topic will overwrite the previous
+      # configuraton.
       #
       # @param topic [String] The topic's name
-      # @param partitions_with_offsets [Hash{Integer => Integer}, Array<Consumer::Partition>] The topic's
-      #   partitions and offsets (Hash) or partitions with offsets and metadata (Array)
+      # @param partitions_with_offsets [Hash{Integer => Integer}, Array<Consumer::Partition>]
+      #   The topic's partitions and offsets (Hash) or partitions with offsets and metadata (Array)
       # @return [nil]
       def add_topic_and_partitions_with_offsets(topic, partitions_with_offsets)
         @data[topic.to_s] = partitions_with_offsets.map do |p, o|
@@ -73,7 +77,8 @@ module Rdkafka
         end
       end
 
-      # Return a `Hash` with the topics as keys and and an array of partition information as the value if present.
+      # Return a `Hash` with the topics as keys and and an array of partition information as the
+      #   value if present.
       #
       # @return [Hash{String => Array<Partition>,nil}]
       def to_h
@@ -97,7 +102,8 @@ module Rdkafka
       #
       # @private
       #
-      # @param pointer [FFI::Pointer] Optional pointer to an existing native list. Its contents will be copied.
+      # @param pointer [FFI::Pointer] Optional pointer to an existing native list. Its contents will
+      #   be copied.
       #
       # @return [TopicPartitionList]
       def self.from_native_tpl(pointer)

--- a/lib/rdkafka/error.rb
+++ b/lib/rdkafka/error.rb
@@ -139,7 +139,8 @@ module Rdkafka
       # Calls rd_kafka_fatal_error() to get the actual underlying error code and description.
       #
       # @param client_ptr [FFI::Pointer] Pointer to rd_kafka_t client
-      # @param fallback_error_code [Integer] Error code to use if no fatal error found (default: -150)
+      # @param fallback_error_code [Integer] Error code to use if no fatal error found
+      #   (default: -150)
       # @param fallback_message [String, nil] Message to use if no fatal error found
       # @param instance_name [String, nil] Optional name of the rdkafka instance
       # @return [RdkafkaError] Error object with fatal flag set to true

--- a/lib/rdkafka/helpers/oauth.rb
+++ b/lib/rdkafka/helpers/oauth.rb
@@ -4,10 +4,14 @@ module Rdkafka
     module OAuth
       # Set the OAuthBearer token
       #
-      # @param token [String] the mandatory token value to set, often (but not necessarily) a JWS compact serialization as per https://tools.ietf.org/html/rfc7515#section-3.1.
-      # @param lifetime_ms [Integer] when the token expires, in terms of the number of milliseconds since the epoch. See https://currentmillis.com/.
+      # @param token [String] the mandatory token value to set, often (but not necessarily) a JWS
+      #   compact serialization as per https://tools.ietf.org/html/rfc7515#section-3.1.
+      # @param lifetime_ms [Integer] when the token expires, in terms of the number of milliseconds
+      #   since the epoch. See https://currentmillis.com/.
       # @param principal_name [String] the mandatory Kafka principal name associated with the token.
-      # @param extensions [Hash] optional SASL extensions key-value pairs to be communicated to the broker as additional key-value pairs during the initial client response as per https://tools.ietf.org/html/rfc7628#section-3.1.
+      # @param extensions [Hash] optional SASL extensions key-value pairs to be communicated to the
+      #   broker as additional key-value pairs during the initial client response as per
+      #   https://tools.ietf.org/html/rfc7628#section-3.1.
       # @return [Integer] 0 on success
       def oauthbearer_set_token(token:, lifetime_ms:, principal_name:, extensions: nil)
         error_buffer = FFI::MemoryPointer.from_string(" " * 256)
@@ -49,7 +53,8 @@ module Rdkafka
       # Convert extensions hash to FFI::MemoryPointer (`const char **`).
       #
       # @param extensions [Hash, nil] extension key-value pairs
-      # @return [Array<FFI::MemoryPointer, Array<FFI::MemoryPointer>>] array pointer and string pointers
+      # @return [Array<FFI::MemoryPointer, Array<FFI::MemoryPointer>>] array pointer and string
+      #   pointers
       # @note The returned pointers must be freed manually (autorelease = false).
       def map_extensions(extensions)
         return [nil, nil] if extensions.nil? || extensions.empty?
@@ -80,7 +85,7 @@ module Rdkafka
       #
       # @param extensions [Hash, nil] extension key-value pairs
       # @return [Integer] non-negative even number representing keys + values count
-      # @see https://github.com/confluentinc/librdkafka/blob/master/src/rdkafka_sasl_oauthbearer.c#L327-L347
+      # @see github.com/confluentinc/librdkafka/blob/master/src/rdkafka_sasl_oauthbearer.c#L327-L347
       def extension_size(extensions)
         return 0 unless extensions
         extensions.size * 2

--- a/lib/rdkafka/native_kafka.rb
+++ b/lib/rdkafka/native_kafka.rb
@@ -139,9 +139,6 @@ module Rdkafka
     # Enable IO event notifications on the main queue
     # Librdkafka will write to your FD when the queue transitions from empty to non-empty
     #
-    # @note This method is incompatible with background polling threads.
-    #   If background polling is enabled, use manual polling instead (e.g., consumer.poll)
-    #
     # @param fd [Integer] your file descriptor (from IO.pipe or eventfd)
     # @param payload [String] data to write to fd when queue has data (default: "\x01")
     # @return [nil]
@@ -158,6 +155,8 @@ module Rdkafka
     #   if readable
     #     consumer.poll(0)  # Get messages
     #   end
+    # @note This method is incompatible with background polling threads.
+    #   If background polling is enabled, use manual polling instead (e.g., consumer.poll)
     def enable_main_queue_io_events(fd, payload = "\x01")
       if @run_polling_thread
         raise "Cannot enable IO events while background polling thread is active. " \
@@ -175,14 +174,13 @@ module Rdkafka
     # Enable IO event notifications on the background queue
     # Librdkafka will write to your FD when the background queue transitions from empty to non-empty
     #
-    # @note This method is incompatible with background polling threads.
-    #   If background polling is enabled, use manual polling instead (e.g., consumer.poll)
-    #
     # @param fd [Integer] your file descriptor (from IO.pipe or eventfd)
     # @param payload [String] data to write to fd when queue has data (default: "\x01")
     # @return [nil]
     # @raise [ClosedInnerError] when the handle is closed
     # @raise [RuntimeError] when background polling thread is active
+    # @note This method is incompatible with background polling threads.
+    #   If background polling is enabled, use manual polling instead (e.g., consumer.poll)
     def enable_background_queue_io_events(fd, payload = "\x01")
       if @run_polling_thread
         raise "Cannot enable IO events while background polling thread is active. " \

--- a/lib/rdkafka/producer.rb
+++ b/lib/rdkafka/producer.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 module Rdkafka
-  # A producer for Kafka messages. To create a producer set up a {Config} and call {Config#producer producer} on that.
+  # A producer for Kafka messages. To create a producer set up a {Config} and call
+  # {Config#producer producer} on that.
   class Producer
     include Helpers::Time
     include Helpers::OAuth
     include Helpers::Metadata
 
-    # @private
+    # @!visibility private
     @@partitions_count_cache = PartitionsCountCache.new
 
     # Global (process wide) partitions cache. We use it to store number of topics partitions,
@@ -175,8 +176,7 @@ module Rdkafka
       end
     end
 
-    # Begin a new transaction
-    # Requires {#init_transactions} to have been called first
+    # Begin a new transaction. Requires {#init_transactions} to have been called first
     #
     # @return [true] Returns true on success
     # @raise [RdkafkaError] if beginning the transaction fails
@@ -331,10 +331,9 @@ module Rdkafka
     # @return [Integer] the number of messages in the queue
     # @raise [Rdkafka::ClosedProducerError] if called on a closed producer
     #
-    # @note This method is thread-safe as it uses the @native_kafka.with_inner synchronization
-    #
     # @example
     #   producer.queue_size #=> 42
+    # @note This method is thread-safe as it uses the @native_kafka.with_inner synchronization
     def queue_size
       closed_producer_check(__method__)
 
@@ -360,10 +359,6 @@ module Rdkafka
     # @return [nil]
     # @raise [Rdkafka::ClosedProducerError] if called on a closed producer
     #
-    # @note This method holds the inner lock until the queue is empty or `:stop` is returned.
-    #   Other producer operations (produce, close, etc.) will wait until this method returns.
-    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
-    #
     # @example Drain all pending callbacks
     #   producer.events_poll_nb_each { |_count| }
     #
@@ -372,6 +367,9 @@ module Rdkafka
     #   producer.events_poll_nb_each do |_count|
     #     :stop if monotonic_now >= deadline
     #   end
+    # @note This method holds the inner lock until the queue is empty or `:stop` is returned.
+    #   Other producer operations (produce, close, etc.) will wait until this method returns.
+    # @note This method is thread-safe as it uses @native_kafka.with_inner synchronization
     def events_poll_nb_each
       closed_producer_check(__method__)
 
@@ -387,7 +385,8 @@ module Rdkafka
     # Partition count for a given topic.
     #
     # @param topic [String] The topic name.
-    # @return [Integer] partition count for a given topic or `RD_KAFKA_PARTITION_UA (-1)` if it could not be obtained.
+    # @return [Integer] partition count for a given topic or `RD_KAFKA_PARTITION_UA (-1)` if it
+    #   could not be obtained.
     #
     # @note If 'allow.auto.create.topics' is set to true in the broker, the topic will be
     #   auto-created after returning nil.
@@ -422,23 +421,32 @@ module Rdkafka
       end
     end
 
-    # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.
+    # Produces a message to a Kafka topic. The message is added to rdkafka's queue, call
+    # {DeliveryHandle#wait wait} on the returned delivery handle to make sure it is delivered.
     #
-    # When no partition is specified the underlying Kafka library picks a partition based on the key. If no key is specified, a random partition will be used.
+    # When no partition is specified the underlying Kafka library picks a partition based on the
+    # key. If no key is specified, a random partition will be used.
     # When a timestamp is provided this is used instead of the auto-generated timestamp.
     #
     # @param topic [String] The topic to produce to
     # @param payload [String, nil]
     # @param key [String, nil]
     # @param partition [Integer, nil] Optional partition to produce to
-    # @param partition_key [String, nil] Optional partition key based on which partition assignment can happen
-    # @param timestamp [Time, Integer, nil] Optional timestamp of this message. Integer timestamp is in milliseconds since Jan 1 1970.
-    # @param headers [Hash{String => String, Array<String>}] Optional message headers. Values can be either a single string or an array of strings to support duplicate headers per KIP-82
-    # @param label [Object, nil] a label that can be assigned when producing a message that will be part of the delivery handle and the delivery report
-    # @param topic_config [Hash] topic config for given message dispatch. Allows to send messages to topics with different configuration
+    # @param partition_key [String, nil] Optional partition key based on which partition
+    #   assignment can happen
+    # @param timestamp [Time, Integer, nil] Optional timestamp of this message. Integer
+    #   timestamp is in milliseconds since Jan 1 1970.
+    # @param headers [Hash{String => String, Array<String>}] Optional message headers. Values
+    #   can be either a single string or an array of strings to support duplicate headers per
+    #   KIP-82
+    # @param label [Object, nil] a label that can be assigned when producing a message that
+    #   will be part of the delivery handle and the delivery report
+    # @param topic_config [Hash] topic config for given message dispatch. Allows to send
+    #   messages to topics with different configuration
     # @param partitioner [String] name of the partitioner to use
     #
-    # @return [DeliveryHandle] Delivery handle that can be used to wait for the result of producing this message
+    # @return [DeliveryHandle] Delivery handle that can be used to wait for the result of
+    #   producing this message
     #
     # @raise [RdkafkaError] When adding the message to rdkafka's queue failed
     def produce(

--- a/lib/rdkafka/producer/delivery_handle.rb
+++ b/lib/rdkafka/producer/delivery_handle.rb
@@ -2,8 +2,7 @@
 
 module Rdkafka
   class Producer
-    # Handle to wait for a delivery report which is returned when
-    # producing a message.
+    # Handle to wait for a delivery report which is returned when producing a message.
     class DeliveryHandle < Rdkafka::AbstractHandle
       layout :pending, :bool,
         :response, :int,

--- a/lib/rdkafka/producer/testing.rb
+++ b/lib/rdkafka/producer/testing.rb
@@ -36,7 +36,8 @@ module Rdkafka
     # Checks if a fatal error has occurred and retrieves error details.
     # Calls rd_kafka_fatal_error to get the actual fatal error code and message.
     #
-    # @return [Hash, nil] Hash with :error_code and :error_string if fatal error occurred, nil otherwise
+    # @return [Hash, nil] Hash with :error_code and :error_string if fatal error occurred,
+    #   nil otherwise
     #
     # @example
     #   if fatal_error = producer.fatal_error


### PR DESCRIPTION
Bring karafka-rdkafka in line with the karafka/mensfeld yard-lint standard (the same rollout applied to rdkafka-ruby and the rest of the ecosystem):

- Bump yard-lint 1.4.0 -> 1.10.2 (Gemfile.lint.lock)
- Enable new cops as errors:
  - Documentation/DuplicateNamespaceComment
  - Documentation/UnderfilledLines (MaxLength 100, matching RuboCop Layout/LineLength)
  - Documentation/LineLength (MaxLength 100)
  - Documentation/TextSubstitution (em/en-dash -> hyphen)
- Promote Tags/ExampleSyntax from warning to error
- Expand Tags/Order to the ecosystem-wide order (param, option, yield*, return, raise, see, example, note, todo)
- Fix all resulting documentation offenses: reflow over-long doc lines and underfilled paragraphs, reorder tag blocks, and convert two genuinely orphaned FFI attach_function tag comments (@see / @param) to prose.
- Express internal class-variable visibility markers with the '@!visibility private' directive instead of the bare '@private' tag, so YARD keeps hiding them without OrphanedDocComment flagging the doc comment.

Comment-only changes in lib/**; no Ruby code was modified. 'bundle exec yard-lint lib' and 'bundle exec rubocop' both pass locally.